### PR TITLE
Handle comments that appear inside of structs, enums and services

### DIFF
--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -352,6 +352,54 @@ describe('Parser', () => {
     assert.deepEqual(thrift, expected)
   });
 
+  it('should correctly parse an enum with field commented out', function() {
+    const content: string = `
+      enum Test {
+        ONE,
+        # TWO
+      }
+    `;
+
+    const scanner: Scanner = createScanner(content);
+    const tokens: Array<Token> = scanner.scan();
+
+    const parser: Parser = createParser(tokens);
+    const thrift: ThriftDocument = parser.parse();
+
+    const expected: ThriftDocument = {
+      type: SyntaxType.ThriftDocument,
+      body: [
+        {
+          type: SyntaxType.EnumDefinition,
+          name: createIdentifier('Test', {
+            start: { line: 2, column: 12, index: 12 },
+            end: { line: 2, column: 16, index: 16 }
+          }),
+          members: [
+            {
+              type: SyntaxType.EnumMember,
+              name: createIdentifier('ONE', {
+                start: { line: 3, column: 9, index: 27 },
+                end: { line: 3, column: 12, index: 30 }
+              }),
+              initializer: null,
+              loc: {
+                start: { line: 3, column: 9, index: 27 },
+                end: { line: 3, column: 12, index: 30 }
+              }
+            }
+          ],
+          loc: {
+            start: { line: 2, column: 7, index: 7 },
+            end: { line: 5, column: 8, index: 53 }
+          }
+        }
+      ]
+    };
+
+    assert.deepEqual(thrift, expected);
+  });
+
   it('should correctly parse the syntax of an enum with initialized member', () => {
     const content: string = `
       enum Test {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -188,8 +188,8 @@ export function createParser(tkns: Array<Token>): Parser {
   function parseFunctions(): Array<FunctionDefinition> {
     const functions: Array<FunctionDefinition> = [];
 
-    while(!check(SyntaxType.RightBraceToken)) {
-      if (currentToken().type === SyntaxType.CommentBlock || currentToken().type === SyntaxType.CommentLine) {
+    while (!check(SyntaxType.RightBraceToken)) {
+      if (check(SyntaxType.CommentBlock, SyntaxType.CommentLine)) {
         advance();
       } else {
         functions.push(parseFunction());
@@ -236,7 +236,7 @@ export function createParser(tkns: Array<Token>): Parser {
     const openParen: Token = consume(SyntaxType.LeftParenToken);
     requireValue(openParen, `Opening paren expected to start list of fields`);
 
-    while(!match(SyntaxType.RightParenToken)) {
+    while (!check(SyntaxType.RightParenToken)) {
       readListSeparator();
       fields.push(parseField());
 
@@ -403,7 +403,7 @@ export function createParser(tkns: Array<Token>): Parser {
   function parseEnumMembers(): Array<EnumMember> {
     const members: Array<EnumMember> = [];
     while (!check(SyntaxType.RightBraceToken)) {
-      if (match(SyntaxType.CommentBlock, SyntaxType.CommentLine)) {
+      if (check(SyntaxType.CommentBlock, SyntaxType.CommentLine)) {
         advance();
       } else {
         members.push(parseEnumMember());
@@ -515,8 +515,8 @@ export function createParser(tkns: Array<Token>): Parser {
   function parseFields(): Array<FieldDefinition> {
     const fields: Array<FieldDefinition> = [];
 
-    while(!check(SyntaxType.RightBraceToken)) {
-      if (currentToken().type === SyntaxType.CommentBlock || currentToken().type === SyntaxType.CommentLine) {
+    while (!check(SyntaxType.RightBraceToken)) {
+      if (check(SyntaxType.CommentBlock, SyntaxType.CommentLine)) {
         advance();
       } else {
         fields.push(parseField());
@@ -566,7 +566,7 @@ export function createParser(tkns: Array<Token>): Parser {
   // ListSeparator → ',' | ';'
   function readListSeparator(): Token {
     const current: Token = currentToken();
-    if (match(SyntaxType.CommaToken, SyntaxType.SemicolonToken)) {
+    if (check(SyntaxType.CommaToken, SyntaxType.SemicolonToken)) {
       return advance();
     }
 
@@ -691,7 +691,7 @@ export function createParser(tkns: Array<Token>): Parser {
 
   function readListValues(): Array<ConstValue> {
     const elements: Array<ConstValue> = [];
-    while(true) {
+    while (true) {
       elements.push(parseValue());
 
       if (check(SyntaxType.CommaToken, SyntaxType.SemicolonToken)) {
@@ -832,17 +832,6 @@ export function createParser(tkns: Array<Token>): Parser {
 
   function peekNext(): Token {
     return tokens[currentIndex + 2];
-  }
-
-  // Does the current token match one in a list of types
-  function match(...types: Array<SyntaxType>): boolean {
-    for (let i = 0; i < types.length; i++) {
-      if (check(types[i])) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   // Does the current token match the given type

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -188,15 +188,17 @@ export function createParser(tkns: Array<Token>): Parser {
   function parseFunctions(): Array<FunctionDefinition> {
     const functions: Array<FunctionDefinition> = [];
 
-    while(true) {
-      functions.push(parseFunction());
+    while(!check(SyntaxType.RightBraceToken)) {
+      if (currentToken().type === SyntaxType.CommentBlock || currentToken().type === SyntaxType.CommentLine) {
+        advance();
+      } else {
+        functions.push(parseFunction());
 
-      if (check(SyntaxType.RightBraceToken)) {
-        break;
-      } else if (isStatementBeginning(currentToken())) {
-        throw new ParseError(`Closing curly brace expected, but new statement found`);
-      } else if (check(SyntaxType.EOF)) {
-        throw new ParseError(`Closing curly brace expected but reached end of file`);
+        if (isStatementBeginning(currentToken())) {
+          throw new ParseError(`closing curly brace expected, but new statement found`);
+        } else if (check(SyntaxType.EOF)) {
+          throw new ParseError(`closing curly brace expected but reached end of file`);
+        }
       }
     }
 
@@ -376,14 +378,14 @@ export function createParser(tkns: Array<Token>): Parser {
   function parseEnum(): EnumDefinition {
     const keywordToken: Token = advance();
     const idToken: Token = consume(SyntaxType.Identifier);
-    requireValue(idToken, `expected identifier for enum definition`);
+    requireValue(idToken, `Expected identifier for enum definition`);
     
     const openBrace: Token = consume(SyntaxType.LeftBraceToken);
-    requireValue(openBrace, `expected opening brace`);
+    requireValue(openBrace, `Expected opening brace`);
     
     const members: Array<EnumMember> = parseEnumMembers();
     const closeBrace: Token = consume(SyntaxType.RightBraceToken);
-    requireValue(closeBrace, `expected closing brace`);
+    requireValue(closeBrace, `Expected closing brace`);
 
     const loc: TextLocation = {
       start: keywordToken.loc.start,
@@ -400,10 +402,19 @@ export function createParser(tkns: Array<Token>): Parser {
 
   function parseEnumMembers(): Array<EnumMember> {
     const members: Array<EnumMember> = [];
-    while (check(SyntaxType.Identifier)) {
-      members.push(parseEnumMember());
-      if (match(SyntaxType.CommaToken, SyntaxType.SemicolonToken)) {
+    while (!check(SyntaxType.RightBraceToken)) {
+      if (match(SyntaxType.CommentBlock, SyntaxType.CommentLine)) {
         advance();
+      } else {
+        members.push(parseEnumMember());
+
+        // consume list separator if there is one
+        readListSeparator();
+        if (isStatementBeginning(currentToken())) {
+          throw new ParseError(`Closing curly brace expected, but new statement found`);
+        } else if (check(SyntaxType.EOF)) {
+          throw new ParseError(`Closing curly brace expected but reached end of file`);
+        }
       }
     }
 
@@ -438,7 +449,7 @@ export function createParser(tkns: Array<Token>): Parser {
     const keywordToken: Token = advance();
     const idToken: Token = advance();
     const openBrace: Token = consume(SyntaxType.LeftBraceToken);
-    requireValue(openBrace, `struct body must begin with opening curly brace`);
+    requireValue(openBrace, `Struct body must begin with opening curly brace`);
 
     const fields: Array<FieldDefinition> = parseFields();
     const closeBrace: Token = advance();
@@ -459,7 +470,7 @@ export function createParser(tkns: Array<Token>): Parser {
     const keywordToken: Token = advance();
     const idToken: Token = advance();
     const openBrace: Token = consume(SyntaxType.LeftBraceToken);
-    requireValue(openBrace, `union body must begin with opening curly brace`);
+    requireValue(openBrace, `Union body must begin with opening curly brace`);
 
     const fields: Array<FieldDefinition> = parseFields();
     const closeBrace: Token = advance();
@@ -484,11 +495,11 @@ export function createParser(tkns: Array<Token>): Parser {
     const keywordToken: Token = advance();
     const idToken: Token = advance();
     const openBrace: Token = consume(SyntaxType.LeftBraceToken);
-    requireValue(openBrace, `exception body must begin with opening curly brace '{'`);
+    requireValue(openBrace, `Exception body must begin with opening curly brace '{'`);
 
     const fields: Array<FieldDefinition> = parseFields();
     const closeBrace: Token = advance();
-    requireValue(closeBrace, `exception body must end with a closing curly brace '}'`)
+    requireValue(closeBrace, `Exception body must end with a closing curly brace '}'`)
 
     return {
       type: SyntaxType.ExceptionDefinition,
@@ -505,12 +516,16 @@ export function createParser(tkns: Array<Token>): Parser {
     const fields: Array<FieldDefinition> = [];
 
     while(!check(SyntaxType.RightBraceToken)) {
-      fields.push(parseField());
+      if (currentToken().type === SyntaxType.CommentBlock || currentToken().type === SyntaxType.CommentLine) {
+        advance();
+      } else {
+        fields.push(parseField());
 
-      if (isStatementBeginning(currentToken())) {
-        throw new ParseError(`closing curly brace expected, but new statement found`);
-      } else if (check(SyntaxType.EOF)) {
-        throw new ParseError(`closing curly brace expected but reached end of file`);
+        if (isStatementBeginning(currentToken())) {
+          throw new ParseError(`Closing curly brace expected, but new statement found`);
+        } else if (check(SyntaxType.EOF)) {
+          throw new ParseError(`Closing curly brace expected but reached end of file`);
+        }
       }
     }
 
@@ -747,15 +762,15 @@ export function createParser(tkns: Array<Token>): Parser {
   // MapType → 'map' CppType? '<' FieldType ',' FieldType '>'
   function parseMapType(): MapType {
     const openBracket: Token = consume(SyntaxType.LessThanToken);
-    requireValue(openBracket, `map needs to defined contained types`);
+    requireValue(openBracket, `Map needs to defined contained types`);
 
     const keyType: FieldType = parseFieldType();
     const commaToken: Token = consume(SyntaxType.CommaToken);
-    requireValue(commaToken, `comma expedted to separate map types <key, value>`);
+    requireValue(commaToken, `Comma expedted to separate map types <key, value>`);
 
     const valueType: FieldType = parseFieldType();
     const closeBracket: Token = consume(SyntaxType.GreaterThanToken);
-    requireValue(closeBracket, `map needs to defined contained types`);
+    requireValue(closeBracket, `Map needs to defined contained types`);
 
     const location: TextLocation = {
       start: openBracket.loc.start,
@@ -768,11 +783,11 @@ export function createParser(tkns: Array<Token>): Parser {
   // SetType → 'set' CppType? '<' FieldType '>'
   function parseSetType(): SetType {
     const openBracket: Token = consume(SyntaxType.LessThanToken);
-    requireValue(openBracket, `map needs to defined contained types`);
+    requireValue(openBracket, `Map needs to defined contained types`);
 
     const valueType: FieldType = parseFieldType();
     const closeBracket: Token = consume(SyntaxType.GreaterThanToken);
-    requireValue(closeBracket, `map needs to defined contained types`);
+    requireValue(closeBracket, `Map needs to defined contained types`);
 
     return {
       type: SyntaxType.SetType,
@@ -787,11 +802,11 @@ export function createParser(tkns: Array<Token>): Parser {
   // ListType → 'list' '<' FieldType '>' CppType?
   function parseListType(): ListType {
     const openBracket: Token = consume(SyntaxType.LessThanToken);
-    requireValue(openBracket, `map needs to defined contained types`);
+    requireValue(openBracket, `Map needs to defined contained types`);
 
     const valueType: FieldType = parseFieldType();
     const closeBracket: Token = consume(SyntaxType.GreaterThanToken);
-    requireValue(closeBracket, `map needs to defined contained types`);
+    requireValue(closeBracket, `Map needs to defined contained types`);
 
     return {
       type: SyntaxType.ListType,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -195,9 +195,9 @@ export function createParser(tkns: Array<Token>): Parser {
         functions.push(parseFunction());
 
         if (isStatementBeginning(currentToken())) {
-          throw new ParseError(`closing curly brace expected, but new statement found`);
+          throw new ParseError(`Closing curly brace expected, but new statement found`);
         } else if (check(SyntaxType.EOF)) {
-          throw new ParseError(`closing curly brace expected but reached end of file`);
+          throw new ParseError(`Closing curly brace expected but reached end of file`);
         }
       }
     }
@@ -330,10 +330,10 @@ export function createParser(tkns: Array<Token>): Parser {
     const keywordToken: Token = advance();
     const fieldType: FieldType = parseFieldType();
     const idToken: Token = advance();
-    requireValue(idToken, `const definition must have a name`);
+    requireValue(idToken, `Const definition must have a name`);
 
     const initializer: ConstValue = parseValueAssignment();
-    requireValue(initializer, `const must be initialized to a value`);
+    requireValue(initializer, `Const must be initialized to a value`);
 
     return {
       type: SyntaxType.ConstDefinition,
@@ -361,7 +361,7 @@ export function createParser(tkns: Array<Token>): Parser {
     const keywordToken: Token = advance();
     const type: DefinitionType = parseDefinitionType();
     const idToken: Token = consume(SyntaxType.Identifier);
-    requireValue(idToken, `typedef is expected to have name and none found`);
+    requireValue(idToken, `Typedef is expected to have name and none found`);
 
     return {
       type: SyntaxType.TypedefDefinition,
@@ -766,7 +766,7 @@ export function createParser(tkns: Array<Token>): Parser {
 
     const keyType: FieldType = parseFieldType();
     const commaToken: Token = consume(SyntaxType.CommaToken);
-    requireValue(commaToken, `Comma expedted to separate map types <key, value>`);
+    requireValue(commaToken, `Comma expected to separate map types <key, value>`);
 
     const valueType: FieldType = parseFieldType();
     const closeBracket: Token = consume(SyntaxType.GreaterThanToken);


### PR DESCRIPTION
Fixed #7 

Previously comments that appeared inside of a struct, enum or service would error:

This was fine:
```
// comment here
struct MyStruct {
  1: required i32 field1;
}
```

This wasn't:
```
struct MyStruct {
  // 1: required i32 field1;
}
```