### PR TITLE
Allow any identifier to be used as namespace scope

### DIFF
--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -207,8 +207,6 @@ describe('Parser', () => {
       ]
     };
 
-    console.log('actual: ', JSON.stringify(thrift, null, 2));
-
     assert.deepEqual(thrift, expected);
   });
 

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -99,6 +99,7 @@ describe('Parser', () => {
   it('should correctly parse the syntax of a namespace definition', () => {
     const content: string = `
       namespace js test
+      namespace js.ts test
     `;
     const scanner: Scanner = createScanner(content);
     const tokens: Array<Token> = scanner.scan();
@@ -128,7 +129,7 @@ describe('Parser', () => {
             }
           },
           scope: {
-            type: SyntaxType.NamespaceScope,
+            type: SyntaxType.Identifier,
             value: 'js',
             loc: {
               start: {
@@ -155,9 +156,58 @@ describe('Parser', () => {
               index: 24
             }
           }
+        },
+        {
+          type: SyntaxType.NamespaceDefinition,
+          name: {
+            type: SyntaxType.Identifier,
+            value: 'test',
+            loc: {
+              start: {
+                line: 3,
+                column: 23,
+                index: 47
+              },
+              end: {
+                line: 3,
+                column: 27,
+                index: 51
+              }
+            }
+          },
+          scope: {
+            type: SyntaxType.Identifier,
+            value: 'js.ts',
+            loc: {
+              start: {
+                line: 3,
+                column: 17,
+                index: 41
+              },
+              end: {
+                line: 3,
+                column: 22,
+                index: 46
+              }
+            }
+          },
+          loc: {
+            start: {
+              line: 3,
+              column: 7,
+              index: 31
+            },
+            end: {
+              line: 3,
+              column: 27,
+              index: 51
+            }
+          }
         }
       ]
     };
+
+    console.log('actual: ', JSON.stringify(thrift, null, 2));
 
     assert.deepEqual(thrift, expected);
   });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -299,46 +299,20 @@ export function createParser(tkns: Array<Token>): Parser {
   // Namespace → 'namespace' ( NamespaceScope Identifier )
   function parseNamespace(): NamespaceDefinition {
     const keywordToken: Token = advance();
-    const scope: NamespaceScope = parseNamespaceScope();
-    const idToken: Token = consume(SyntaxType.Identifier);
-    requireValue(idToken, `Unable to find identifier for namespace`);
+    const scopeToken: Token = consume(SyntaxType.Identifier);
+    requireValue(scopeToken, `Unable to find scope identifier for namespace`);
+    
+    const nameToken: Token = consume(SyntaxType.Identifier);
+    requireValue(nameToken, `Unable to find name identifier for namespace`);
 
     return {
       type: SyntaxType.NamespaceDefinition,
-      scope: scope,
-      name: createIdentifier(idToken.text, idToken.loc),
+      scope: createIdentifier(scopeToken.text, scopeToken.loc),
+      name: createIdentifier(nameToken.text, nameToken.loc),
       loc: createTextLocation(
         keywordToken.loc.start,
-        idToken.loc.end
+        nameToken.loc.end
       )
-    }
-  }
-
-  // NamespaceScope → '*' | 'cpp' | 'java' | 'py' | 'perl' | 'rb' | 'cocoa' | 'csharp' | 'js'
-  function parseNamespaceScope(): NamespaceScope {
-    const current: Token = currentToken();
-    switch(current.text) {
-      case '*':
-      case 'js':
-      case 'cpp':
-      case 'java':
-      case 'py':
-      case 'perl':
-      case 'rb':
-      case 'cocoa':
-      case 'csharp':
-        advance();
-        return {
-          type: SyntaxType.NamespaceScope,
-          value: current.text,
-          loc: {
-            start: current.loc.start,
-            end: current.loc.end
-          }
-        };
-
-      default:
-        throw new ParseError(`Invalid or missing namespace scope: ${current.text}`);
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,14 +79,12 @@ export type ConstValue =
 
 export interface NamespaceDefinition extends SyntaxNode {
   type: SyntaxType.NamespaceDefinition;
-  scope: NamespaceScope;
+  scope: Identifier;
   name: Identifier;
 }
 
-export interface NamespaceScope extends SyntaxNode {
-  type: SyntaxType.NamespaceScope;
-  value: '*' | 'cpp' | 'java' | 'py' | 'perl' | 'rb' | 'cocoa' | 'csharp' | 'js'
-}
+export type NamespaceScope =
+  '*' | 'cpp' | 'java' | 'py' | 'perl' | 'rb' | 'cocoa' | 'csharp' | 'js'
 
 export interface ConstDefinition extends SyntaxNode {
   type: SyntaxType.ConstDefinition;


### PR DESCRIPTION
Fixes #9   

* Maybe in codegen we warn if it's not one of the standard scopes?