### PR TITLE
Handle inline block comment, leave comments in AST, some additional cleanup

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,5 +1,6 @@
 import {
   Token,
+  Comment,
   Identifier,
   FieldType,
   FieldRequired,
@@ -54,8 +55,9 @@ export function createFieldDefinition(
   fieldID: FieldID,
   requiredness: FieldRequired,
   fieldType: FieldType,
-  defaultValue: ConstValue,
-  loc: TextLocation
+  loc: TextLocation,
+  defaultValue: ConstValue = null,
+  comments: Array<Comment> = []
 ): FieldDefinition {
   return {
     type: SyntaxType.FieldDefinition,
@@ -64,6 +66,7 @@ export function createFieldDefinition(
     requiredness,
     fieldType,
     defaultValue,
+    comments,
     loc
   };
 }
@@ -76,11 +79,17 @@ export function createFieldID(value: number, loc: TextLocation): FieldID {
   };
 }
 
-export function createStructDefinition(name: Identifier, fields: Array<FieldDefinition>, loc: TextLocation): StructDefinition {
+export function createStructDefinition(
+  name: Identifier,
+  fields: Array<FieldDefinition>,
+  loc: TextLocation,
+  comments: Array<Comment> = []
+): StructDefinition {
   return {
     type: SyntaxType.StructDefinition,
     name,
     fields,
+    comments,
     loc
   };
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -22,7 +22,8 @@ import {
   TextLocation,
   TextPosition,
   StructDefinition,
-  FieldDefinition
+  FieldDefinition,
+  FunctionType
 } from './types';
 
 export function createTextLocation(start: TextPosition, end: TextPosition): TextLocation {
@@ -54,7 +55,7 @@ export function createFieldDefinition(
   name: Identifier,
   fieldID: FieldID,
   requiredness: FieldRequired,
-  fieldType: FieldType,
+  fieldType: FunctionType,
   loc: TextLocation,
   defaultValue: ConstValue = null,
   comments: Array<Comment> = []

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -685,6 +685,78 @@ describe('Parser', () => {
     assert.deepEqual(thrift, expected);
   });
 
+  it('should correctly parse the syntax of an exception', () => {
+    const content: string = `
+      exception Test {
+        1: required string message;
+      }
+    `;
+    const scanner: Scanner = createScanner(content);
+    const tokens: Array<Token> = scanner.scan();
+
+    const parser: Parser = createParser(tokens);
+    const thrift: ThriftDocument = parser.parse();
+
+    const expected: ThriftDocument = {
+      type: SyntaxType.ThriftDocument,
+      body: [
+        {
+          type: SyntaxType.ExceptionDefinition,
+          name: {
+            type: SyntaxType.Identifier,
+            value: 'Test',
+            loc: {
+              start: { line: 2, column: 17, index: 17 },
+              end: { line: 2, column: 21, index: 21 }
+            }
+          },
+          fields: [
+            {
+              type: SyntaxType.FieldDefinition,
+              name: {
+                type: SyntaxType.Identifier,
+                value: 'message',
+                loc: {
+                  start: { line: 3, column: 28, index: 51 },
+                  end: { line: 3, column: 35, index: 58 }
+                }
+              },
+              fieldID: {
+                type: SyntaxType.FieldID,
+                value: 1,
+                loc: {
+                  start: { line: 3, column: 9, index: 32 },
+                  end: { line: 3, column: 11, index: 34 }
+                }
+              },
+              fieldType: {
+                type: SyntaxType.StringKeyword,
+                loc: {
+                  start: { line: 3, column: 21, index: 44 },
+                  end: { line: 3, column: 27, index: 50 }
+                }
+              },
+              requiredness: 'required',
+              defaultValue: null,
+              comments: [],
+              loc: {
+                start: { line: 3, column: 9, index: 32 },
+                end: { line: 3, column: 36, index: 59 }
+              }
+            }
+          ],
+          comments: [],
+          loc: {
+            start: { line: 2, column: 7, index: 7 },
+            end: { line: 4, column: 8, index: 67 }
+          }
+        }
+      ]
+    };
+
+    assert.deepEqual(thrift, expected);
+  });
+  
   it('should correctly parse the syntax of a struct with commented fields', () => {
     const content: string = `
       struct Test {

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -1272,7 +1272,12 @@ describe('Parser', () => {
     const content: string = `
       // This service does nothing
       /*
-       * Not even a little bit
+       * This is a multi-line
+       * comment for testing
+       */
+      /*
+       Another muliti-line
+       comment for testing
        */
       service Test {
         bool /* should this be required? */ ping()
@@ -1297,14 +1302,14 @@ describe('Parser', () => {
             value: 'Test',
             loc: {
               start: {
-                line: 5,
+                line: 9,
                 column: 15,
-                index: 100
+                index: 201
               },
               end: {
-                line: 5,
+                line: 9,
                 column: 19,
-                index: 104
+                index: 205
               }
             }
           },
@@ -1317,14 +1322,14 @@ describe('Parser', () => {
                 value: 'ping',
                 loc: {
                   start: {
-                    line: 6,
+                    line: 10,
                     column: 45,
-                    index: 151
+                    index: 252
                   },
                   end: {
-                    line: 6,
+                    line: 10,
                     column: 49,
-                    index: 155
+                    index: 256
                   }
                 }
               },
@@ -1332,14 +1337,14 @@ describe('Parser', () => {
                 type: SyntaxType.BoolKeyword,
                 loc: {
                   start: {
-                    line: 6,
+                    line: 10,
                     column: 9,
-                    index: 115
+                    index: 216
                   },
                   end: {
-                    line: 6,
+                    line: 10,
                     column: 13,
-                    index: 119
+                    index: 220
                   }
                 }
               },
@@ -1351,14 +1356,14 @@ describe('Parser', () => {
                   value: 'should this be required?',
                   loc: {
                     start: {
-                      line: 6,
+                      line: 10,
                       column: 14,
-                      index: 120
+                      index: 221
                     },
                     end: {
-                      line: 6,
+                      line: 10,
                       column: 44,
-                      index: 150
+                      index: 251
                     }
                   }
                 },
@@ -1367,14 +1372,14 @@ describe('Parser', () => {
                   value: 'bool foo();',
                   loc: {
                     start: {
-                      line: 7,
+                      line: 11,
                       column: 9,
-                      index: 166
+                      index: 267
                     },
                     end: {
-                      line: 7,
+                      line: 11,
                       column: 22,
-                      index: 179
+                      index: 280
                     }
                   }
                 },
@@ -1383,28 +1388,28 @@ describe('Parser', () => {
                   value: 'string dang(),',
                   loc: {
                     start: {
-                      line: 8,
+                      line: 12,
                       column: 9,
-                      index: 188
+                      index: 289
                     },
                     end: {
-                      line: 8,
+                      line: 12,
                       column: 26,
-                      index: 205
+                      index: 306
                     }
                   }
                 }
               ],
               loc: {
                 start: {
-                  line: 6,
+                  line: 10,
                   column: 9,
-                  index: 115
+                  index: 216
                 },
                 end: {
-                  line: 6,
+                  line: 10,
                   column: 51,
-                  index: 157
+                  index: 258
                 }
               }
             },
@@ -1415,14 +1420,14 @@ describe('Parser', () => {
                 value: 'ding',
                 loc: {
                   start: {
-                    line: 9,
+                    line: 13,
                     column: 13,
-                    index: 218
+                    index: 319
                   },
                   end: {
-                    line: 9,
+                    line: 13,
                     column: 17,
-                    index: 222
+                    index: 323
                   }
                 }
               },
@@ -1430,14 +1435,14 @@ describe('Parser', () => {
                 type: SyntaxType.I32Keyword,
                 loc: {
                   start: {
-                    line: 9,
+                    line: 13,
                     column: 9,
-                    index: 214
+                    index: 315
                   },
                   end: {
-                    line: 9,
+                    line: 13,
                     column: 12,
-                    index: 217
+                    index: 318
                   }
                 }
               },
@@ -1446,14 +1451,14 @@ describe('Parser', () => {
               comments: [],
               loc: {
                 start: {
-                  line: 9,
+                  line: 13,
                   column: 9,
-                  index: 214
+                  index: 315
                 },
                 end: {
-                  line: 9,
+                  line: 13,
                   column: 19,
-                  index: 224
+                  index: 325
                 }
               }
             }
@@ -1477,7 +1482,7 @@ describe('Parser', () => {
             },
             {
               type: SyntaxType.CommentBlock,
-              value: 'Not even a little bit',
+              value: 'This is a multi-line\n comment for testing',
               loc: {
                 start: {
                   line: 3,
@@ -1485,23 +1490,39 @@ describe('Parser', () => {
                   index: 42
                 },
                 end: {
-                  line: 4,
+                  line: 5,
                   column: 11,
-                  index: 85
+                  index: 113
+                }
+              }
+            },
+            {
+              type: SyntaxType.CommentBlock,
+              value: 'Another muliti-line\n comment for testing',
+              loc: {
+                start: {
+                  line: 6,
+                  column: 7,
+                  index: 120
+                },
+                end: {
+                  line: 8,
+                  column: 11,
+                  index: 186
                 }
               }
             }
           ],
           loc: {
             start: {
-              line: 5,
+              line: 9,
               column: 7,
-              index: 92
+              index: 193
             },
             end: {
-              line: 10,
+              line: 14,
               column: 8,
-              index: 232
+              index: 333
             }
           }
         }

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -9,6 +9,213 @@ import {
 } from './factory';
 
 describe('Parser', () => {
+  it('should correctly parse the syntax of a const', () => {
+    const content: string = `
+      const map<string,string> MAP_CONST = {'hello': 'world', 'foo': 'bar' }
+    `;
+    const scanner: Scanner = createScanner(content);
+    const tokens: Array<Token> = scanner.scan();
+
+    const parser: Parser = createParser(tokens);
+    const thrift: ThriftDocument = parser.parse();
+
+    const expected: ThriftDocument = {
+      type: SyntaxType.ThriftDocument,
+      body: [
+        {
+          type: SyntaxType.ConstDefinition,
+          name: {
+            type: SyntaxType.Identifier,
+            value: 'MAP_CONST',
+            loc: {
+              start: {
+                line: 2,
+                column: 32,
+                index: 32
+              },
+              end: {
+                line: 2,
+                column: 41,
+                index: 41
+              }
+            }
+          },
+          fieldType: {
+            type: SyntaxType.MapType,
+            keyType: {
+              type: SyntaxType.StringKeyword,
+              loc: {
+                start: {
+                  line: 2,
+                  column: 17,
+                  index: 17
+                },
+                end: {
+                  line: 2,
+                  column: 23,
+                  index: 23
+                }
+              }
+            },
+            valueType: {
+              type: SyntaxType.StringKeyword,
+              loc: {
+                start: {
+                  line: 2,
+                  column: 24,
+                  index: 24
+                },
+                end: {
+                  line: 2,
+                  column: 30,
+                  index: 30
+                }
+              }
+            },
+            loc: {
+              start: {
+                line: 2,
+                column: 16,
+                index: 16
+              },
+              end: {
+                line: 2,
+                column: 31,
+                index: 31
+              }
+            }
+          },
+          initializer: {
+            type: SyntaxType.ConstMap,
+            properties: [
+              {
+                type: SyntaxType.PropertyAssignment,
+                name: {
+                  type: SyntaxType.StringLiteral,
+                  value: 'hello',
+                  loc: {
+                    start: {
+                      line: 2,
+                      column: 45,
+                      index: 45
+                    },
+                    end: {
+                      line: 2,
+                      column: 52,
+                      index: 52
+                    }
+                  }
+                },
+                initializer: {
+                  type: SyntaxType.StringLiteral,
+                  value: 'world',
+                  loc: {
+                    start: {
+                      line: 2,
+                      column: 54,
+                      index: 54
+                    },
+                    end: {
+                      line: 2,
+                      column: 61,
+                      index: 61
+                    }
+                  }
+                },
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 45,
+                    index: 45
+                  },
+                  end: {
+                    line: 2,
+                    column: 61,
+                    index: 61
+                  }
+                }
+              },
+              {
+                type: SyntaxType.PropertyAssignment,
+                name: {
+                  type: SyntaxType.StringLiteral,
+                  value: 'foo',
+                  loc: {
+                    start: {
+                      line: 2,
+                      column: 63,
+                      index: 63
+                    },
+                    end: {
+                      line: 2,
+                      column: 68,
+                      index: 68
+                    }
+                  }
+                },
+                initializer: {
+                  type: SyntaxType.StringLiteral,
+                  value: 'bar',
+                  loc: {
+                    start: {
+                      line: 2,
+                      column: 70,
+                      index: 70
+                    },
+                    end: {
+                      line: 2,
+                      column: 75,
+                      index: 75
+                    }
+                  }
+                },
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 63,
+                    index: 63
+                  },
+                  end: {
+                    line: 2,
+                    column: 75,
+                    index: 75
+                  }
+                }
+              }
+            ],
+            loc: {
+              start: {
+                line: 2,
+                column: 45,
+                index: 45
+              },
+              end: {
+                line: 2,
+                column: 77,
+                index: 77
+              }
+            }
+          },
+          comments: [],
+          loc: {
+            start: {
+              line: 2,
+              column: 7,
+              index: 7
+            },
+            end: {
+              line: 2,
+              column: 77,
+              index: 77
+            }
+          }
+        }
+      ]
+    };
+
+    assert.deepEqual(thrift, expected);
+  });
+  
   it('should correctly parse the syntax of a typedef definition', () => {
     const content: string = `
       typedef string name

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -215,7 +215,7 @@ describe('Parser', () => {
 
     assert.deepEqual(thrift, expected);
   });
-  
+
   it('should correctly parse the syntax of a typedef definition', () => {
     const content: string = `
       typedef string name
@@ -318,7 +318,9 @@ describe('Parser', () => {
           comments: [
             {
               type: SyntaxType.CommentBlock,
-              value: 'string is name',
+              value: [
+                'string is name'
+              ],
               loc: {
                 start: {
                   line: 2,
@@ -756,7 +758,7 @@ describe('Parser', () => {
 
     assert.deepEqual(thrift, expected);
   });
-  
+
   it('should correctly parse the syntax of a struct with commented fields', () => {
     const content: string = `
       struct Test {
@@ -1632,7 +1634,9 @@ describe('Parser', () => {
               comments: [
                 {
                   type: SyntaxType.CommentBlock,
-                  value: 'should this be required?',
+                  value: [
+                    'should this be required?'
+                  ],
                   loc: {
                     start: {
                       line: 10,
@@ -1761,7 +1765,10 @@ describe('Parser', () => {
             },
             {
               type: SyntaxType.CommentBlock,
-              value: 'This is a multi-line\n comment for testing',
+              value: [
+                'This is a multi-line',
+                ' comment for testing'
+              ],
               loc: {
                 start: {
                   line: 3,
@@ -1777,7 +1784,10 @@ describe('Parser', () => {
             },
             {
               type: SyntaxType.CommentBlock,
-              value: 'Another muliti-line\n comment for testing',
+              value: [
+                'Another muliti-line',
+                ' comment for testing'
+              ],
               loc: {
                 start: {
                   line: 6,

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -923,7 +923,7 @@ describe('Parser', () => {
     assert.deepEqual(thrift, expected)
   });
 
-  it('should correctly parse an enum with field commented out', function() {
+  it('should correctly parse an enum with field commented out', () => {
     const content: string = `
       enum Test {
         ONE,
@@ -1821,7 +1821,7 @@ describe('Parser', () => {
     assert.deepEqual(thrift, expected);
   });
 
-  it('should correctly parse a service containing a function with custom type', function() {
+  it('should correctly parse a service containing a function with custom type', () => {
     const content: string = `
       service Test {
         TestType test()
@@ -2195,7 +2195,7 @@ describe('Parser', () => {
     assert.deepEqual(thrift, expected);
   });
 
-  it('parses a service containing a function with arguments with mixed FieldIDs', function() {
+  it('parses a service containing a function with arguments with mixed FieldIDs', () => {
     const content: string = `
       service Test {
         void test(string test1, 1: bool test2)

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -35,6 +35,7 @@ describe('Parser', () => {
               end: { line: 2, column: 21, index: 21 }
             }
           },
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 2, column: 26, index: 26 }
@@ -69,9 +70,65 @@ describe('Parser', () => {
             start: { line: 2, column: 15, index: 15 },
             end: { line: 2, column: 23, index: 23 }
           }),
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 2, column: 28, index: 28 }
+          }
+        }
+      ]
+    }
+
+    assert.deepEqual(thrift, expected)
+  });
+
+  it('should correctly parse inline block comments', () => {
+    const content: string = `
+      typedef /* string is name */ string name
+    `;
+    const scanner: Scanner = createScanner(content);
+    const tokens: Array<Token> = scanner.scan();
+
+    const parser: Parser = createParser(tokens);
+    const thrift: ThriftDocument = parser.parse();
+
+    const expected: ThriftDocument = {
+      type: SyntaxType.ThriftDocument,
+      body: [
+        {
+          type: SyntaxType.TypedefDefinition,
+          name: createIdentifier('name', {
+            start: { line: 2, column: 43, index: 43 },
+            end: { line: 2, column: 47, index: 47 }
+          }),
+          definitionType: {
+            type: SyntaxType.StringKeyword,
+            loc: {
+              start: { line: 2, column: 36, index: 36 },
+              end: { line: 2, column: 42, index: 42 }
+            }
+          },
+          comments: [
+            {
+              type: SyntaxType.CommentBlock,
+              value: 'string is name',
+              loc: {
+                start: {
+                  line: 2,
+                  column: 15,
+                  index: 15
+                },
+                end: {
+                  line: 2,
+                  column: 35,
+                  index: 35
+                }
+              }
+            }
+          ],
+          loc: {
+            start: { line: 2, column: 7, index: 7 },
+            end: { line: 2, column: 47, index: 47 }
           }
         }
       ]
@@ -111,6 +168,7 @@ describe('Parser', () => {
               }
             }
           },
+          comments: [],
           loc: {
             start: {
               line: 2,
@@ -178,6 +236,7 @@ describe('Parser', () => {
               }
             }
           },
+          comments: [],
           loc: {
             start: {
               line: 2,
@@ -225,6 +284,7 @@ describe('Parser', () => {
               }
             }
           },
+          comments: [],
           loc: {
             start: {
               line: 3,
@@ -300,6 +360,7 @@ describe('Parser', () => {
               },
               requiredness: 'required',
               defaultValue: null,
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 29 },
                 end: { line: 3, column: 31, index: 51 }
@@ -332,6 +393,7 @@ describe('Parser', () => {
               },
               requiredness: 'required',
               defaultValue: null,
+              comments: [],
               loc: {
                 start: { line: 4, column: 9, index: 60 },
                 end: { line: 4, column: 31, index: 82 }
@@ -364,6 +426,7 @@ describe('Parser', () => {
               },
               requiredness: 'optional',
               defaultValue: null,
+              comments: [],
               loc: {
                 start: { line: 5, column: 9, index: 91 },
                 end: { line: 5, column: 34, index: 116 }
@@ -396,12 +459,14 @@ describe('Parser', () => {
               },
               requiredness: 'required',
               defaultValue: null,
+              comments: [],
               loc: {
                 start: { line: 6, column: 9, index: 125 },
                 end: { line: 6, column: 34, index: 150 }
               }
             }
           ],
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 7, column: 8, index: 158 }
@@ -467,9 +532,28 @@ describe('Parser', () => {
               },
               requiredness: 'required',
               defaultValue: null,
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 29 },
                 end: { line: 3, column: 32, index: 52 }
+              }
+            }
+          ],
+          comments: [
+            {
+              type: SyntaxType.CommentLine,
+              value: '2: required bool field2,',
+              loc: {
+                start: {
+                  line: 4,
+                  column: 9,
+                  index: 61
+                },
+                end: {
+                  line: 4,
+                  column: 35,
+                  index: 87
+                }
               }
             }
           ],
@@ -522,6 +606,7 @@ describe('Parser', () => {
                 }
               },
               initializer: null,
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 27 },
                 end: { line: 3, column: 12, index: 30 }
@@ -538,12 +623,14 @@ describe('Parser', () => {
                 }
               },
               initializer: null,
+              comments: [],
               loc: {
                 start: { line: 4, column: 9, index: 40 },
                 end: { line: 4, column: 12, index: 43 }
               }
             }
           ],
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 5, column: 8, index: 51 }
@@ -586,9 +673,28 @@ describe('Parser', () => {
                 end: { line: 3, column: 12, index: 30 }
               }),
               initializer: null,
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 27 },
                 end: { line: 3, column: 12, index: 30 }
+              }
+            }
+          ],
+          comments: [
+            {
+              type: SyntaxType.CommentLine,
+              value: 'TWO',
+              loc: {
+                start: {
+                  line: 4,
+                  column: 9,
+                  index: 40
+                },
+                end: {
+                  line: 4,
+                  column: 14,
+                  index: 45
+                }
               }
             }
           ],
@@ -649,6 +755,7 @@ describe('Parser', () => {
                   end: { line: 3, column: 16, index: 34 }
                 }
               },
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 27 },
                 end: { line: 3, column: 16, index: 34 }
@@ -665,12 +772,14 @@ describe('Parser', () => {
                 }
               },
               initializer: null,
+              comments: [],
               loc: {
                 start: { line: 4, column: 9, index: 44 },
                 end: { line: 4, column: 12, index: 47 }
               }
             }
           ],
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 5, column: 8, index: 55 }
@@ -728,6 +837,7 @@ describe('Parser', () => {
                   end: { line: 3, column: 19, index: 37 }
                 }
               },
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 27 },
                 end: { line: 3, column: 19, index: 37 }
@@ -744,12 +854,14 @@ describe('Parser', () => {
                 }
               },
               initializer: null,
+              comments: [],
               loc: {
                 start: { line: 4, column: 9, index: 47 },
                 end: { line: 4, column: 12, index: 50 }
               }
             }
           ],
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 5, column: 8, index: 58 }
@@ -760,7 +872,7 @@ describe('Parser', () => {
 
     assert.deepEqual(thrift, expected)
   });
-    
+
   it('should correctly parse the syntax of a simple service', () => {
     const content: string = `
       service Test {
@@ -802,6 +914,7 @@ describe('Parser', () => {
                   end: { line: 3, column: 13, index: 34 }
                 }
               },
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 30 },
                 end: { line: 3, column: 20, index: 41 }
@@ -809,6 +922,7 @@ describe('Parser', () => {
             }
           ],
           extends: null,
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 4, column: 8, index: 49 }
@@ -893,6 +1007,7 @@ describe('Parser', () => {
               },
               fields: [],
               throws: [],
+              comments: [],
               loc: {
                 start: {
                   line: 3,
@@ -941,6 +1056,7 @@ describe('Parser', () => {
               },
               fields: [],
               throws: [],
+              comments: [],
               loc: {
                 start: {
                   line: 4,
@@ -989,6 +1105,7 @@ describe('Parser', () => {
               },
               fields: [],
               throws: [],
+              comments: [],
               loc: {
                 start: {
                   line: 5,
@@ -1037,6 +1154,7 @@ describe('Parser', () => {
               },
               fields: [],
               throws: [],
+              comments: [],
               loc: {
                 start: {
                   line: 6,
@@ -1051,6 +1169,7 @@ describe('Parser', () => {
               }
             }
           ],
+          comments: [],
           loc: {
             start: {
               line: 2,
@@ -1112,6 +1231,24 @@ describe('Parser', () => {
                   end: { line: 3, column: 13, index: 34 }
                 }
               },
+              comments: [
+                {
+                  type: SyntaxType.CommentLine,
+                  value: 'void ping()',
+                  loc: {
+                    start: {
+                      line: 4,
+                      column: 9,
+                      index: 50
+                    },
+                    end: {
+                      line: 4,
+                      column: 22,
+                      index: 63
+                    }
+                  }
+                }
+              ],
               loc: {
                 start: { line: 3, column: 9, index: 30 },
                 end: { line: 3, column: 20, index: 41 }
@@ -1119,9 +1256,253 @@ describe('Parser', () => {
             }
           ],
           extends: null,
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 5, column: 8, index: 71 }
+          }
+        }
+      ]
+    };
+
+    assert.deepEqual(thrift, expected);
+  });
+
+  it('should correctly parse complex commenting', () => {
+    const content: string = `
+      // This service does nothing
+      /*
+       * Not even a little bit
+       */
+      service Test {
+        bool /* should this be required? */ ping()
+        # bool foo();
+        // string dang(),
+        i32 ding()
+      }
+    `;
+    const scanner: Scanner = createScanner(content);
+    const tokens: Array<Token> = scanner.scan();
+
+    const parser: Parser = createParser(tokens);
+    const thrift: ThriftDocument = parser.parse();
+
+    const expected: ThriftDocument = {
+      type: SyntaxType.ThriftDocument,
+      body: [
+        {
+          type: SyntaxType.ServiceDefinition,
+          name: {
+            type: SyntaxType.Identifier,
+            value: 'Test',
+            loc: {
+              start: {
+                line: 5,
+                column: 15,
+                index: 100
+              },
+              end: {
+                line: 5,
+                column: 19,
+                index: 104
+              }
+            }
+          },
+          extends: null,
+          functions: [
+            {
+              type: SyntaxType.FunctionDefinition,
+              name: {
+                type: SyntaxType.Identifier,
+                value: 'ping',
+                loc: {
+                  start: {
+                    line: 6,
+                    column: 45,
+                    index: 151
+                  },
+                  end: {
+                    line: 6,
+                    column: 49,
+                    index: 155
+                  }
+                }
+              },
+              returnType: {
+                type: SyntaxType.BoolKeyword,
+                loc: {
+                  start: {
+                    line: 6,
+                    column: 9,
+                    index: 115
+                  },
+                  end: {
+                    line: 6,
+                    column: 13,
+                    index: 119
+                  }
+                }
+              },
+              fields: [],
+              throws: [],
+              comments: [
+                {
+                  type: SyntaxType.CommentBlock,
+                  value: 'should this be required?',
+                  loc: {
+                    start: {
+                      line: 6,
+                      column: 14,
+                      index: 120
+                    },
+                    end: {
+                      line: 6,
+                      column: 44,
+                      index: 150
+                    }
+                  }
+                },
+                {
+                  type: SyntaxType.CommentLine,
+                  value: 'bool foo();',
+                  loc: {
+                    start: {
+                      line: 7,
+                      column: 9,
+                      index: 166
+                    },
+                    end: {
+                      line: 7,
+                      column: 22,
+                      index: 179
+                    }
+                  }
+                },
+                {
+                  type: SyntaxType.CommentLine,
+                  value: 'string dang(),',
+                  loc: {
+                    start: {
+                      line: 8,
+                      column: 9,
+                      index: 188
+                    },
+                    end: {
+                      line: 8,
+                      column: 26,
+                      index: 205
+                    }
+                  }
+                }
+              ],
+              loc: {
+                start: {
+                  line: 6,
+                  column: 9,
+                  index: 115
+                },
+                end: {
+                  line: 6,
+                  column: 51,
+                  index: 157
+                }
+              }
+            },
+            {
+              type: SyntaxType.FunctionDefinition,
+              name: {
+                type: SyntaxType.Identifier,
+                value: 'ding',
+                loc: {
+                  start: {
+                    line: 9,
+                    column: 13,
+                    index: 218
+                  },
+                  end: {
+                    line: 9,
+                    column: 17,
+                    index: 222
+                  }
+                }
+              },
+              returnType: {
+                type: SyntaxType.I32Keyword,
+                loc: {
+                  start: {
+                    line: 9,
+                    column: 9,
+                    index: 214
+                  },
+                  end: {
+                    line: 9,
+                    column: 12,
+                    index: 217
+                  }
+                }
+              },
+              fields: [],
+              throws: [],
+              comments: [],
+              loc: {
+                start: {
+                  line: 9,
+                  column: 9,
+                  index: 214
+                },
+                end: {
+                  line: 9,
+                  column: 19,
+                  index: 224
+                }
+              }
+            }
+          ],
+          comments: [
+            {
+              type: SyntaxType.CommentLine,
+              value: 'This service does nothing',
+              loc: {
+                start: {
+                  line: 2,
+                  column: 7,
+                  index: 7
+                },
+                end: {
+                  line: 2,
+                  column: 35,
+                  index: 35
+                }
+              }
+            },
+            {
+              type: SyntaxType.CommentBlock,
+              value: 'Not even a little bit',
+              loc: {
+                start: {
+                  line: 3,
+                  column: 7,
+                  index: 42
+                },
+                end: {
+                  line: 4,
+                  column: 11,
+                  index: 85
+                }
+              }
+            }
+          ],
+          loc: {
+            start: {
+              line: 5,
+              column: 7,
+              index: 92
+            },
+            end: {
+              line: 10,
+              column: 8,
+              index: 232
+            }
           }
         }
       ]
@@ -1170,12 +1551,14 @@ describe('Parser', () => {
                   end: { line: 3, column: 17, index: 38 }
                 }
               },
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 30 },
                 end: { line: 3, column: 24, index: 45 }
               }
             }
           ],
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 4, column: 8, index: 53 }
@@ -1273,6 +1656,7 @@ describe('Parser', () => {
                   },
                   requiredness: null,
                   defaultValue: null,
+                  comments: [],
                   loc: {
                     start: {
                       line: 3,
@@ -1338,6 +1722,7 @@ describe('Parser', () => {
                   },
                   requiredness: null,
                   defaultValue: null,
+                  comments: [],
                   loc: {
                     start: {
                       line: 3,
@@ -1359,6 +1744,7 @@ describe('Parser', () => {
                   end: { line: 3, column: 13, index: 34 }
                 }
               },
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 30 },
                 end: { line: 3, column: 90, index: 111 }
@@ -1366,6 +1752,7 @@ describe('Parser', () => {
             }
           ],
           extends: null,
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 4, column: 8, index: 119 }
@@ -1463,6 +1850,7 @@ describe('Parser', () => {
               },
               fields: [],
               throws: [],
+              comments: [],
               loc: {
                 start: {
                   line: 3,
@@ -1477,6 +1865,7 @@ describe('Parser', () => {
               }
             }
           ],
+          comments: [],
           loc: {
             start: {
               line: 2,
@@ -1495,7 +1884,7 @@ describe('Parser', () => {
 
     assert.deepEqual(thrift, expected);
   });
-  
+
   it('parses a service containing a function with arguments with mixed FieldIDs', function() {
     const content: string = `
       service Test {
@@ -1546,6 +1935,7 @@ describe('Parser', () => {
                       end: { line: 3, column: 25, index: 46 }
                     }
                   },
+                  comments: [],
                   loc: {
                     start: { line: 3, column: 19, index: 40 },
                     end: { line: 3, column: 32, index: 53 }
@@ -1574,6 +1964,7 @@ describe('Parser', () => {
                       end: { line: 3, column: 40, index: 61 }
                     }
                   },
+                  comments: [],
                   loc: {
                     start: { line: 3, column: 33, index: 54 },
                     end: { line: 3, column: 46, index: 67  }
@@ -1588,6 +1979,7 @@ describe('Parser', () => {
                   end: { line: 3, column: 13, index: 34 }
                 }
               },
+              comments: [],
               loc: {
                 start: { line: 3, column: 9, index: 30 },
                 end: { line: 3, column: 47, index: 68 }
@@ -1595,6 +1987,7 @@ describe('Parser', () => {
             }
           ],
           extends: null,
+          comments: [],
           loc: {
             start: { line: 2, column: 7, index: 7 },
             end: { line: 4, column: 8, index: 76 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5,7 +5,6 @@ import {
   Token,
   Comment,
   StructLike,
-  NamespaceScope,
   NamespaceDefinition,
   IncludeDefinition,
   ConstDefinition,
@@ -312,7 +311,7 @@ export function createParser(tokens: Array<Token>): Parser {
     return null;
   }
 
-  // Namespace → 'namespace' ( NamespaceScope Identifier )
+  // Namespace → 'namespace' ( Identifier Identifier )
   function parseNamespace(): NamespaceDefinition {
     const keywordToken: Token = consume(SyntaxType.NamespaceKeyword);
     const scopeToken: Token = consume(SyntaxType.Identifier);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -828,6 +828,14 @@ export function createParser(tokens: Array<Token>): Parser {
       const next: Token = tokens[currentIndex];
       switch (next.type) {
         case SyntaxType.CommentBlock:
+          comments.push({
+            type: next.type,
+            value: next.text.split('\n'),
+            loc: next.loc
+          });
+          currentIndex++;
+          break;
+
         case SyntaxType.CommentLine:
           comments.push({
             type: next.type,
@@ -835,6 +843,7 @@ export function createParser(tokens: Array<Token>): Parser {
             loc: next.loc
           });
           currentIndex++;
+          break;
 
         default:
           return;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -335,7 +335,7 @@ export function createParser(tokens: Array<Token>): Parser {
 
   // ConstDefinition → 'const' FieldType Identifier '=' ConstValue ListSeparator?
   function parseConst(): ConstDefinition {
-    const keywordToken: Token = consume(SyntaxType.Identifier);
+    const keywordToken: Token = consume(SyntaxType.ConstKeyword);
     const fieldType: FieldType = parseFieldType();
     const nameToken: Token = consume(SyntaxType.Identifier);
     requireValue(nameToken, `Const definition must have a name`);
@@ -760,7 +760,7 @@ export function createParser(tokens: Array<Token>): Parser {
         return createKeywordFieldType(typeToken.type, typeToken.loc);
 
       default:
-        throw new ParseError(`FieldType expected`);
+        throw new ParseError(`FieldType expected but found: ${typeToken.type}`);
     }
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -311,7 +311,7 @@ export function createParser(tokens: Array<Token>): Parser {
     return null;
   }
 
-  // Namespace → 'namespace' ( Identifier Identifier )
+  // Namespace → 'namespace' ( NamespaceScope Identifier )
   function parseNamespace(): NamespaceDefinition {
     const keywordToken: Token = consume(SyntaxType.NamespaceKeyword);
     const scopeToken: Token = consume(SyntaxType.Identifier);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,6 +4,7 @@ import {
   Node,
   Token,
   Comment,
+  StructLike,
   NamespaceScope,
   NamespaceDefinition,
   IncludeDefinition,
@@ -433,7 +434,7 @@ export function createParser(tokens: Array<Token>): Parser {
 
   // EnumMember → (Identifier ('=' IntConstant)? ListSeparator?)*
   function parseEnumMember(): EnumMember {
-    const idToken: Token = consume(SyntaxType.Identifier);
+    const nameToken: Token = consume(SyntaxType.Identifier);
     const equalToken: Token = consume(SyntaxType.EqualToken);
     const numToken: Token = consume(SyntaxType.IntegerLiteral, SyntaxType.HexLiteral);
     var loc: TextLocation = null;
@@ -441,34 +442,35 @@ export function createParser(tokens: Array<Token>): Parser {
 
     if (numToken !== null) {
       initializer = createIntConstant(parseInt(numToken.text), numToken.loc);
-      loc = createTextLocation(idToken.loc.start, initializer.loc.end);
+      loc = createTextLocation(nameToken.loc.start, initializer.loc.end);
     } else {
-      loc = createTextLocation(idToken.loc.start, idToken.loc.end);
+      loc = createTextLocation(nameToken.loc.start, nameToken.loc.end);
     }
 
     return {
       type: SyntaxType.EnumMember,
-      name: createIdentifier(idToken.text, idToken.loc),
+      name: createIdentifier(nameToken.text, nameToken.loc),
       initializer,
       comments: getComments(),
       loc
     };
   }
 
-  // StructDefinition → 'struct' Identifier 'xsd_all'? '{' Field* '}'
-  function parseStruct(): StructDefinition {
+  function parseStructLikeInterface(): StructLike {
     const keywordToken: Token = advance();
-    const idToken: Token = advance();
+    const nameToken: Token = consume(SyntaxType.Identifier);
+    requireValue(nameToken, `Struct-like must have an identifier`);
+
     const openBrace: Token = consume(SyntaxType.LeftBraceToken);
-    requireValue(openBrace, `Struct body must begin with opening curly brace`);
+    requireValue(openBrace, `Struct-like body must begin with opening curly brace '{'`);
 
     const leadingComments: Array<Comment> = getComments();
     const fields: Array<FieldDefinition> = parseFields();
-    const closeBrace: Token = advance();
+    const closeBrace: Token = consume(SyntaxType.RightBraceToken);
+    requireValue(closeBrace, `Struct-like body must end with a closing curly brace '}'`);
 
     return {
-      type: SyntaxType.StructDefinition,
-      name: createIdentifier(idToken.text, idToken.loc),
+      name: createIdentifier(nameToken.text, nameToken.loc),
       fields: fields,
       comments: [
         ...leadingComments,
@@ -478,63 +480,49 @@ export function createParser(tokens: Array<Token>): Parser {
         start: keywordToken.loc.start,
         end: closeBrace.loc.end
       }
+    };
+  }
+
+  // StructDefinition → 'struct' Identifier 'xsd_all'? '{' Field* '}'
+  function parseStruct(): StructDefinition {
+    const parsedData: StructLike = parseStructLikeInterface();
+
+    return {
+      type: SyntaxType.StructDefinition,
+      name: parsedData.name,
+      fields: parsedData.fields,
+      comments: parsedData.comments,
+      loc: parsedData.loc
     };
   }
 
   // UnioinDefinition → 'union' Identifier 'xsd_all'? '{' Field* '}'
   function parseUnion(): UnionDefinition {
-    const keywordToken: Token = advance();
-    const idToken: Token = advance();
-    const openBrace: Token = consume(SyntaxType.LeftBraceToken);
-    requireValue(openBrace, `Union body must begin with opening curly brace`);
-
-    const leadingComments: Array<Comment> = getComments();
-    const fields: Array<FieldDefinition> = parseFields();
-    const closeBrace: Token = advance();
+    const parsedData: StructLike = parseStructLikeInterface();
 
     return {
       type: SyntaxType.UnionDefinition,
-      name: createIdentifier(idToken.text, idToken.loc),
-      fields: fields.map((next: FieldDefinition) => {
+      name: parsedData.name,
+      fields: parsedData.fields.map((next: FieldDefinition) => {
         // As per the Thrift spec, all union fields are optional
         next.requiredness = 'optional';
         return next;
       }),
-      comments: [
-        ...leadingComments,
-        ...getComments()
-      ],
-      loc: {
-        start: keywordToken.loc.start,
-        end: closeBrace.loc.end
-      }
+      comments: parsedData.comments,
+      loc: parsedData.loc
     };
   }
 
   // ExceptionDefinition → 'exception' Identifier '{' Field* '}'
   function parseException(): ExceptionDefinition {
-    const keywordToken: Token = advance();
-    const idToken: Token = advance();
-    const openBrace: Token = consume(SyntaxType.LeftBraceToken);
-    requireValue(openBrace, `Exception body must begin with opening curly brace '{'`);
-
-    const leadingComments: Array<Comment> = getComments();
-    const fields: Array<FieldDefinition> = parseFields();
-    const closeBrace: Token = advance();
-    requireValue(closeBrace, `Exception body must end with a closing curly brace '}'`)
+    const parsedData: StructLike = parseStructLikeInterface();
 
     return {
       type: SyntaxType.ExceptionDefinition,
-      name: createIdentifier(idToken.text, idToken.loc),
-      fields: fields,
-      comments: [
-        ...leadingComments,
-        ...getComments()
-      ],
-      loc: {
-        start: keywordToken.loc.start,
-        end: closeBrace.loc.end
-      }
+      name: parsedData.name,
+      fields: parsedData.fields,
+      comments: parsedData.comments,
+      loc: parsedData.loc
     };
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -196,7 +196,7 @@ export function createParser(tokens: Array<Token>): Parser {
 
   function parseExtends(): Identifier {
     if (checkText('extends')) {
-      const keywordToken: Token = consume(SyntaxType.Identifier);
+      const keywordToken: Token = consume(SyntaxType.ExtendsKeyword);
       const nameToken: Token = consume(SyntaxType.Identifier);
       requireValue(nameToken, `Identifier expected after 'extends' keyword`);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -459,7 +459,7 @@ export function createParser(tokens: Array<Token>): Parser {
   }
 
   function parseStructLikeInterface(): StructLike {
-    const keywordToken: Token = consume(SyntaxType.StructKeyword);
+    const keywordToken: Token = consume(SyntaxType.StructKeyword, SyntaxType.UnionKeyword, SyntaxType.ExceptionKeyword);
     const nameToken: Token = consume(SyntaxType.Identifier);
     requireValue(nameToken, `Struct-like must have an identifier`);
 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -263,7 +263,7 @@ export function createScanner(src: string) {
 
   function singleLineComment(): void {
     var comment: string = '';
-    
+
     if (current() === '#') {
       advance();
     } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,9 +148,9 @@ export interface FieldDefinition extends PrimarySyntax {
   type: SyntaxType.FieldDefinition;
   name: Identifier;
   fieldID: FieldID;
-  fieldType: FieldType;
-  requiredness: FieldRequired;
-  defaultValue: ConstValue;
+  fieldType: FunctionType;
+  requiredness: FieldRequired | null;
+  defaultValue: ConstValue | null;
 }
 
 export interface FieldID extends SyntaxNode {
@@ -167,7 +167,7 @@ export interface EnumDefinition extends PrimarySyntax {
 export interface EnumMember extends PrimarySyntax {
   type: SyntaxType.EnumMember;
   name: Identifier;
-  initializer: IntConstant;
+  initializer: IntConstant | null;
 }
 
 export interface TypedefDefinition extends PrimarySyntax {
@@ -179,7 +179,7 @@ export interface TypedefDefinition extends PrimarySyntax {
 export interface ServiceDefinition extends PrimarySyntax {
   type: SyntaxType.ServiceDefinition;
   name: Identifier;
-  extends: Identifier;
+  extends: Identifier | null;
   functions: Array<FunctionDefinition>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,9 +107,6 @@ export interface NamespaceDefinition extends PrimarySyntax {
   name: Identifier;
 }
 
-export type NamespaceScope =
-  '*' | 'cpp' | 'java' | 'py' | 'perl' | 'rb' | 'cocoa' | 'csharp' | 'js'
-
 export interface ConstDefinition extends PrimarySyntax {
   type: SyntaxType.ConstDefinition;
   name: Identifier;
@@ -250,7 +247,6 @@ export const enum SyntaxType {
   ThriftDocument = 'ThriftDocument',
 
   Identifier = 'Identifier',
-  NamespaceScope = 'NamespaceScope',
   FieldID = 'FieldID',
 
   // Statements

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,13 @@ export interface SyntaxNode extends Node {
   loc: TextLocation;
 }
 
+export interface StructLike {
+  name: Identifier;
+  fields: Array<FieldDefinition>;
+  comments: Array<Comment>;
+  loc: TextLocation;
+}
+
 export interface TextLocation {
   start: TextPosition;
   end: TextPosition;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,17 +42,17 @@ export type ThriftStatement =
 export type CommentType =
   SyntaxType.CommentLine | SyntaxType.CommentBlock;
 
-export interface Comment extends SyntaxNode {
-  type: CommentType;
+export type Comment =
+  CommentLine | CommentBlock;
+
+export interface CommentLine extends SyntaxNode {
+  type: SyntaxType.CommentLine;
   value: string;
 }
 
-export interface CommentLine extends Comment {
-  type: SyntaxType.CommentLine;
-}
-
-export interface CommentBlock extends Comment {
+export interface CommentBlock extends SyntaxNode {
   type: SyntaxType.CommentBlock;
+  value: Array<string>;
 }
 
 export interface PrimarySyntax extends SyntaxNode {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,26 @@ export type ThriftStatement =
   StructDefinition | EnumDefinition | ExceptionDefinition | UnionDefinition |
   TypedefDefinition | ServiceDefinition;
 
+export type CommentType =
+  SyntaxType.CommentLine | SyntaxType.CommentBlock;
+
+export interface Comment extends SyntaxNode {
+  type: CommentType;
+  value: string;
+}
+
+export interface CommentLine extends Comment {
+  type: SyntaxType.CommentLine;
+}
+
+export interface CommentBlock extends Comment {
+  type: SyntaxType.CommentBlock;
+}
+
+export interface PrimarySyntax extends SyntaxNode {
+  comments: Array<Comment>;
+}
+
 export type FieldType =
   BaseType | ContainerType | Identifier;
 
@@ -74,7 +94,7 @@ export type ConstValue =
   Identifier | StringLiteral | IntConstant | DoubleConstant |
   BooleanLiteral | ConstMap | ConstList;
 
-export interface NamespaceDefinition extends SyntaxNode {
+export interface NamespaceDefinition extends PrimarySyntax {
   type: SyntaxType.NamespaceDefinition;
   scope: Identifier;
   name: Identifier;
@@ -83,7 +103,7 @@ export interface NamespaceDefinition extends SyntaxNode {
 export type NamespaceScope =
   '*' | 'cpp' | 'java' | 'py' | 'perl' | 'rb' | 'cocoa' | 'csharp' | 'js'
 
-export interface ConstDefinition extends SyntaxNode {
+export interface ConstDefinition extends PrimarySyntax {
   type: SyntaxType.ConstDefinition;
   name: Identifier;
   fieldType: FieldType;
@@ -93,17 +113,17 @@ export interface ConstDefinition extends SyntaxNode {
 export type FieldRequired =
   'required' | 'optional';
 
-export interface IncludeDefinition extends SyntaxNode {
+export interface IncludeDefinition extends PrimarySyntax {
   type: SyntaxType.IncludeDefinition;
   path: StringLiteral;
 }
 
-export interface CppIncludeDefinition extends SyntaxNode {
+export interface CppIncludeDefinition extends PrimarySyntax {
   type: SyntaxType.CppIncludeDefinition;
   path: StringLiteral;
 }
 
-export interface InterfaceWithFields extends SyntaxNode {
+export interface InterfaceWithFields extends PrimarySyntax {
   name: Identifier;
   fields: Array<FieldDefinition>;
 }
@@ -120,7 +140,7 @@ export interface ExceptionDefinition extends InterfaceWithFields {
   type: SyntaxType.ExceptionDefinition;
 }
 
-export interface FieldDefinition extends SyntaxNode {
+export interface FieldDefinition extends PrimarySyntax {
   type: SyntaxType.FieldDefinition;
   name: Identifier;
   fieldID: FieldID;
@@ -134,32 +154,32 @@ export interface FieldID extends SyntaxNode {
   value: number;
 }
 
-export interface EnumDefinition extends SyntaxNode {
+export interface EnumDefinition extends PrimarySyntax {
   type: SyntaxType.EnumDefinition;
   name: Identifier;
   members: Array<EnumMember>;
 }
 
-export interface EnumMember extends SyntaxNode {
+export interface EnumMember extends PrimarySyntax {
   type: SyntaxType.EnumMember;
   name: Identifier;
   initializer: IntConstant;
 }
 
-export interface TypedefDefinition extends SyntaxNode {
+export interface TypedefDefinition extends PrimarySyntax {
   type: SyntaxType.TypedefDefinition;
   name: Identifier;
   definitionType: FieldType;
 }
 
-export interface ServiceDefinition extends SyntaxNode {
+export interface ServiceDefinition extends PrimarySyntax {
   type: SyntaxType.ServiceDefinition;
   name: Identifier;
   extends: Identifier;
   functions: Array<FunctionDefinition>;
 }
 
-export interface FunctionDefinition extends SyntaxNode {
+export interface FunctionDefinition extends PrimarySyntax {
   type: SyntaxType.FunctionDefinition;
   name: Identifier;
   returnType: FunctionType;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "outDir": "./dist",
     "noImplicitAny": true,
     "noImplicitThis": true,
-    "listEmittedFiles": true,
     "pretty": true,
     "removeComments": false,
     "lib": [


### PR DESCRIPTION
Fixes #17 and adds #16

Allows for inline block comments
Leaves comments in AST by associating them with closest node (with leading preference)