### PR TITLE
Fix parsing of empty list and empty map

### DIFF
--- a/src/main/factory.ts
+++ b/src/main/factory.ts
@@ -126,7 +126,7 @@ export function createStringLiteral(value: string, loc: TextLocation): StringLit
   }
 }
 
-export function createIntConstant(value: number, loc: TextLocation): IntConstant {
+export function createIntConstant(value: string, loc: TextLocation): IntConstant {
   return { type: SyntaxType.IntConstant, value, loc }
 }
 

--- a/src/main/parser.ts
+++ b/src/main/parser.ts
@@ -465,7 +465,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
     if (equalToken !== null) {
       const numToken: Token = consume(SyntaxType.IntegerLiteral, SyntaxType.HexLiteral)
       requireValue(numToken, `Equals token "=" must be followed by an Integer`)
-      initializer = createIntConstant(parseInt(numToken.text), numToken.loc)
+      initializer = createIntConstant(numToken.text, numToken.loc)
       loc = createTextLocation(nameToken.loc.start, initializer.loc.end)
     }
     else {
@@ -655,7 +655,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
 
       case SyntaxType.IntegerLiteral:
       case SyntaxType.HexLiteral:
-        return createIntConstant(parseInt(next.text), next.loc)
+        return createIntConstant(next.text, next.loc)
 
       case SyntaxType.FloatLiteral:
       case SyntaxType.ExponentialLiteral:

--- a/src/main/parser.ts
+++ b/src/main/parser.ts
@@ -682,7 +682,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
   function parseMapValue(): ConstMap {
     // The parseValue method has already advanced the cursor
     const startLoc: TextLocation = currentToken().loc
-    const properties: Array<PropertyAssignment> = readMapValues()
+    const properties: Array<PropertyAssignment> = check(SyntaxType.RightBraceToken) ? [] : readMapValues()
     const closeBrace: Token = consume(SyntaxType.RightBraceToken)
     requireValue(closeBrace, `Closing brace missing from map definition`)
 
@@ -699,7 +699,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
   function parseListValue(): ConstList {
     // The parseValue method has already advanced the cursor
     const startLoc: TextLocation = currentToken().loc
-    const elements: Array<ConstValue> = readListValues()
+    const elements: Array<ConstValue> = check(SyntaxType.RightBracketToken) ? [] : readListValues()
     const closeBrace: Token = consume(SyntaxType.RightBracketToken)
     requireValue(closeBrace, `Closing square-bracket missing from list definition`)
     const endLoc: TextLocation = closeBrace.loc

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -234,7 +234,7 @@ export interface BooleanLiteral extends SyntaxNode {
 
 export interface IntConstant extends SyntaxNode {
   type: SyntaxType.IntConstant
-  value: number
+  value: string
 }
 
 export interface DoubleConstant extends SyntaxNode {

--- a/src/tests/parser.spec.ts
+++ b/src/tests/parser.spec.ts
@@ -1037,7 +1037,7 @@ describe('Parser', () => {
               },
               initializer: {
                 type: SyntaxType.IntConstant,
-                value: 2,
+                value: '2',
                 loc: {
                   start: { line: 3, column: 15, index: 33 },
                   end: { line: 3, column: 16, index: 34 },
@@ -1119,7 +1119,7 @@ describe('Parser', () => {
               },
               initializer: {
                 type: SyntaxType.IntConstant,
-                value: 175,
+                value: '0xaf',
                 loc: {
                   start: { line: 3, column: 15, index: 33 },
                   end: { line: 3, column: 19, index: 37 },

--- a/src/tests/parser.spec.ts
+++ b/src/tests/parser.spec.ts
@@ -2658,4 +2658,213 @@ describe('Parser', () => {
 
     assert.deepEqual(thrift, expected)
   })
+
+  it('should correctly parse an empty list', () => {
+    const content: string = `
+      const list<string> EMPTY_LIST = []
+    `
+    const scanner: Scanner = createScanner(content)
+    const tokens: Array<Token> = scanner.scan()
+
+    const parser: Parser = createParser(tokens)
+    const thrift: ThriftDocument = parser.parse()
+
+    const expected: ThriftDocument = {
+      type: SyntaxType.ThriftDocument,
+      body: [
+        {
+          comments: [],
+          fieldType: {
+            loc: {
+              end: {
+                column: 25,
+                index: 25,
+                line: 2,
+              },
+              start: {
+                column: 17,
+                index: 17,
+                line: 2,
+              },
+            },
+            type: SyntaxType.ListType,
+            valueType: {
+              loc: {
+                end: {
+                  column: 24,
+                  index: 24,
+                  line: 2,
+                },
+                start: {
+                  column: 18,
+                  index: 18,
+                  line: 2,
+                },
+              },
+              type: SyntaxType.StringKeyword,
+            },
+          },
+          initializer: {
+            elements: [],
+            loc: {
+              end: {
+                column: 41,
+                index: 41,
+                line: 2,
+              },
+              start: {
+                column: 40,
+                index: 40,
+                line: 2,
+              },
+            },
+            type: SyntaxType.ConstList,
+          },
+          loc: {
+            end: {
+              column: 41,
+              index: 41,
+              line: 2,
+            },
+            start: {
+              column: 7,
+              index: 7,
+              line: 2,
+            },
+          },
+          name: {
+            loc: {
+              end: {
+                column: 36,
+                index: 36,
+                line: 2,
+              },
+              start: {
+                column: 26,
+                index: 26,
+                line: 2,
+              },
+            },
+            type: SyntaxType.Identifier,
+            value: 'EMPTY_LIST',
+          },
+          type: SyntaxType.ConstDefinition,
+        },
+      ],
+    }
+
+    assert.deepEqual(thrift, expected)
+  })
+
+  it('should correctly parse an empty map', () => {
+    const content: string = `
+      const map<string, string> EMPTY_MAP = {}
+    `
+    const scanner: Scanner = createScanner(content)
+    const tokens: Array<Token> = scanner.scan()
+
+    const parser: Parser = createParser(tokens)
+    const thrift: ThriftDocument = parser.parse()
+
+    const expected: ThriftDocument = {
+      type: SyntaxType.ThriftDocument,
+      body: [
+        {
+          type: SyntaxType.ConstDefinition,
+          name: {
+            type: SyntaxType.Identifier,
+            value: 'EMPTY_MAP',
+            loc: {
+              start: {
+                line: 2,
+                column: 33,
+                index: 33,
+              },
+              end: {
+                line: 2,
+                column: 42,
+                index: 42,
+              },
+            },
+          },
+          fieldType: {
+            type: SyntaxType.MapType,
+            keyType: {
+              type: SyntaxType.StringKeyword,
+              loc: {
+                start: {
+                  line: 2,
+                  column: 17,
+                  index: 17,
+                },
+                end: {
+                  line: 2,
+                  column: 23,
+                  index: 23,
+                },
+              },
+            },
+            valueType: {
+              type: SyntaxType.StringKeyword,
+              loc: {
+                start: {
+                  line: 2,
+                  column: 25,
+                  index: 25,
+                },
+                end: {
+                  line: 2,
+                  column: 31,
+                  index: 31,
+                },
+              },
+            },
+            loc: {
+              start: {
+                line: 2,
+                column: 16,
+                index: 16,
+              },
+              end: {
+                line: 2,
+                column: 32,
+                index: 32,
+              },
+            },
+          },
+          initializer: {
+            type: SyntaxType.ConstMap,
+            properties: [],
+            loc: {
+              start: {
+                line: 2,
+                column: 46,
+                index: 46,
+              },
+              end: {
+                line: 2,
+                column: 47,
+                index: 47,
+              },
+            },
+          },
+          comments: [],
+          loc: {
+            start: {
+              line: 2,
+              column: 7,
+              index: 7,
+            },
+            end: {
+              line: 2,
+              column: 47,
+              index: 47,
+            },
+          },
+        },
+      ],
+    }
+
+    assert.deepEqual(thrift, expected)
+  })
 })


### PR DESCRIPTION
Added a check for "RightBracketToken" or "RightBraceToken" before reading list or map values. If the check passes, then it is an empty list or empty map.

Previously, it would read and consume the "RightBracketToken" or "RightBraceToken" immediately and would attempt to find the next "RightBracketToken" or "RightBraceToken", which would usually result in a parsing failure.