### PR TITLE
Treat int constant values as strings, move numerical parsing to compiler

### DIFF
--- a/src/main/factory.ts
+++ b/src/main/factory.ts
@@ -126,7 +126,7 @@ export function createStringLiteral(value: string, loc: TextLocation): StringLit
   }
 }
 
-export function createIntConstant(value: number, loc: TextLocation): IntConstant {
+export function createIntConstant(value: string, loc: TextLocation): IntConstant {
   return { type: SyntaxType.IntConstant, value, loc }
 }
 

--- a/src/main/parser.ts
+++ b/src/main/parser.ts
@@ -465,7 +465,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
     if (equalToken !== null) {
       const numToken: Token = consume(SyntaxType.IntegerLiteral, SyntaxType.HexLiteral)
       requireValue(numToken, `Equals token "=" must be followed by an Integer`)
-      initializer = createIntConstant(parseInt(numToken.text), numToken.loc)
+      initializer = createIntConstant(numToken.text, numToken.loc)
       loc = createTextLocation(nameToken.loc.start, initializer.loc.end)
     }
     else {
@@ -655,7 +655,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
 
       case SyntaxType.IntegerLiteral:
       case SyntaxType.HexLiteral:
-        return createIntConstant(parseInt(next.text), next.loc)
+        return createIntConstant(next.text, next.loc)
 
       case SyntaxType.FloatLiteral:
       case SyntaxType.ExponentialLiteral:

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -234,7 +234,7 @@ export interface BooleanLiteral extends SyntaxNode {
 
 export interface IntConstant extends SyntaxNode {
   type: SyntaxType.IntConstant
-  value: number
+  value: string
 }
 
 export interface DoubleConstant extends SyntaxNode {

--- a/src/tests/parser.spec.ts
+++ b/src/tests/parser.spec.ts
@@ -1037,7 +1037,7 @@ describe('Parser', () => {
               },
               initializer: {
                 type: SyntaxType.IntConstant,
-                value: 2,
+                value: '2',
                 loc: {
                   start: { line: 3, column: 15, index: 33 },
                   end: { line: 3, column: 16, index: 34 },
@@ -1119,7 +1119,7 @@ describe('Parser', () => {
               },
               initializer: {
                 type: SyntaxType.IntConstant,
-                value: 175,
+                value: '0xaf',
                 loc: {
                   start: { line: 3, column: 15, index: 33 },
                   end: { line: 3, column: 19, index: 37 },


### PR DESCRIPTION
Change `IntConstant.value` to `string` and remove `parseInt`.

Fixes: https://github.com/creditkarma/thrift-parser/pull/36