### PR TITLE
Removed const from enum declarations

### DIFF
--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -283,12 +283,12 @@ export interface Identifier extends SyntaxNode {
   value: string
 }
 
-export const enum ErrorType {
+export enum ErrorType {
   ParseError = 'ParseError',
   ScanError = 'ScanError',
 }
 
-export const enum SyntaxType {
+export enum SyntaxType {
   ThriftDocument = 'ThriftDocument',
   ThriftErrors = 'ThriftErrors',
 


### PR DESCRIPTION
Removed const from enum declarations in order to enable JavaScript code generation for enums