### PR TITLE
Properly map comments to data

### DIFF
--- a/src/main/parser.ts
+++ b/src/main/parser.ts
@@ -184,6 +184,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
 
   // ServiceDefinition → 'service' Identifier ( 'extends' Identifier )? '{' Function* '}'
   function parseService(): ServiceDefinition {
+    const leadingComments: Array<Comment> = getComments()
     const keywordToken: Token = consume(SyntaxType.ServiceKeyword)
     const nameToken: Token = consume(SyntaxType.Identifier)
     requireValue(nameToken, `Unable to find identifier for service`)
@@ -191,8 +192,6 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
     const extendsId: Identifier = parseExtends()
     const openBrace: Token = consume(SyntaxType.LeftBraceToken)
     requireValue(openBrace, `Expected opening curly brace`)
-
-    const leadingComments: Array<Comment> = getComments()
 
     const functions: Array<FunctionDefinition> = parseFunctions()
     const closeBrace: Token = consume(SyntaxType.RightBraceToken)
@@ -205,10 +204,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
       name: createIdentifier(nameToken.text, nameToken.loc),
       extends: extendsId,
       functions,
-      comments: [
-        ...leadingComments,
-        ...getComments(),
-      ],
+      comments: leadingComments,
       loc: location,
     }
   }
@@ -250,6 +246,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
 
   // Function → 'oneway'? FunctionType Identifier '(' Field* ')' Throws? ListSeparator?
   function parseFunction(): FunctionDefinition {
+    const leadingComments: Array<Comment> = getComments()
     const onewayToken: Token = consume(SyntaxType.OnewayKeyword)
     const returnType: FunctionType = parseFunctionType()
 
@@ -275,7 +272,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
       returnType,
       fields: params.fields,
       throws: (throws !== null) ? throws.fields : [],
-      comments: getComments(),
+      comments: leadingComments,
       oneway: (onewayToken !== null),
       modifiers: (
         (onewayToken !== null) ?
@@ -360,6 +357,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
 
   // ConstDefinition → 'const' FieldType Identifier '=' ConstValue ListSeparator?
   function parseConst(): ConstDefinition {
+    const leadingComments: Array<Comment> = getComments()
     const keywordToken: Token = consume(SyntaxType.ConstKeyword)
     const fieldType: FieldType = parseFieldType()
     const nameToken: Token = consume(SyntaxType.Identifier)
@@ -374,7 +372,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
       name: createIdentifier(nameToken.text, nameToken.loc),
       fieldType,
       initializer,
-      comments: getComments(),
+      comments: leadingComments,
       loc: {
         start: keywordToken.loc.start,
         end: initializer.loc.end,
@@ -412,6 +410,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
 
   // EnumDefinition → 'enum' Identifier '{' EnumMember* '}'
   function parseEnum(): EnumDefinition {
+    const leadingComments: Array<Comment> = getComments()
     const keywordToken: Token = consume(SyntaxType.EnumKeyword)
     const nameToken: Token = consume(SyntaxType.Identifier)
     requireValue(nameToken, `Expected identifier for enum definition`)
@@ -432,7 +431,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
       type: SyntaxType.EnumDefinition,
       name: createIdentifier(nameToken.text, nameToken.loc),
       members,
-      comments: getComments(),
+      comments: leadingComments,
       loc,
     }
   }
@@ -486,6 +485,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
 
   // StructLike → ('struct' | 'union' | 'exception') Identifier 'xsd_all'? '{' Field* '}'
   function parseStructLikeInterface(): StructLike {
+    const leadingComments: Array<Comment> = getComments()
     const keywordToken: Token = consume(SyntaxType.StructKeyword, SyntaxType.UnionKeyword, SyntaxType.ExceptionKeyword)
     const nameToken: Token = consume(SyntaxType.Identifier)
     requireValue(nameToken, `Struct-like must have an identifier`)
@@ -493,7 +493,6 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
     const openBrace: Token = consume(SyntaxType.LeftBraceToken)
     requireValue(openBrace, `Struct-like body must begin with opening curly brace '{'`)
 
-    const leadingComments: Array<Comment> = getComments()
     const fields: Array<FieldDefinition> = parseFields()
     const closeBrace: Token = consume(SyntaxType.RightBraceToken)
     requireValue(closeBrace, `Struct-like body must end with a closing curly brace '}'`)
@@ -501,10 +500,7 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
     return {
       name: createIdentifier(nameToken.text, nameToken.loc),
       fields,
-      comments: [
-        ...leadingComments,
-        ...getComments(),
-      ],
+      comments: leadingComments,
       loc: {
         start: keywordToken.loc.start,
         end: closeBrace.loc.end,

--- a/src/tests/parser/fixtures/comments-mapping.thrift
+++ b/src/tests/parser/fixtures/comments-mapping.thrift
@@ -1,0 +1,53 @@
+/**
+ * Multiline typedef
+ * comment
+ */
+typedef i32 MyInteger
+
+/**
+ * Const1 comment
+ */
+const i32 INT32CONSTANT = 9853
+
+// Const2 comment
+const string STRINGCONSTANT = 'hello world'
+
+/**
+ * Enum comment
+ */
+enum Operation {
+  ADD = 1,
+  // Enum field comment
+  MULTIPLY
+}
+
+/**
+ * Struct comment
+ */
+struct Work {
+  1: i32 num1 = 0,
+  // Struct field comment
+  2: Operation op,
+}
+
+/**
+ * Service comment
+ */
+service Calculator extends shared.SharedService {
+
+  /**
+   * Function 1 comment
+   */
+
+   i32 add(1:MyInteger num1, 2:i32 num2),
+
+   /**
+   * Function 2 comment
+   */
+   oneway void zip(1:i32 vasia)
+
+}
+
+/**
+ * Ignored comment
+ */

--- a/src/tests/parser/fixtures/complex-comments.thrift
+++ b/src/tests/parser/fixtures/complex-comments.thrift
@@ -8,7 +8,6 @@ Another muliti-line
 comment for testing
 */
 service Test {
-    bool /* should this be required? */ ping()
     # bool foo();
     // string dang(),
     i32 ding()

--- a/src/tests/parser/parser.spec.ts
+++ b/src/tests/parser/parser.spec.ts
@@ -375,4 +375,17 @@ describe('Parser', () => {
 
         assert.deepEqual(thrift, expected)
     })
+
+    it('should map comments correctly', () => {
+        const content: string = loadSource('comments-mapping')
+        const scanner: Scanner = createScanner(content)
+        const tokens: Array<Token> = scanner.scan()
+
+        const parser: Parser = createParser(tokens)
+        const thrift: ThriftDocument = parser.parse()
+
+        const expected: any = loadSolution('comments-mapping')
+
+        assert.deepEqual(thrift, expected)
+    })
 })

--- a/src/tests/parser/solutions/comments-mapping.solution.json
+++ b/src/tests/parser/solutions/comments-mapping.solution.json
@@ -1,0 +1,1070 @@
+{
+  "type": "ThriftDocument",
+  "body": [
+    {
+      "type": "TypedefDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "MyInteger",
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 13,
+            "index": 52
+          },
+          "end": {
+            "line": 5,
+            "column": 22,
+            "index": 61
+          }
+        }
+      },
+      "definitionType": {
+        "type": "I32Keyword",
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 9,
+            "index": 48
+          },
+          "end": {
+            "line": 5,
+            "column": 12,
+            "index": 51
+          }
+        }
+      },
+      "comments": [
+        {
+          "type": "CommentBlock",
+          "value": [
+            "Multiline typedef",
+            " comment"
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "index": 0
+            },
+            "end": {
+              "line": 4,
+              "column": 4,
+              "index": 39
+            }
+          }
+        }
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "index": 40
+        },
+        "end": {
+          "line": 5,
+          "column": 22,
+          "index": 61
+        }
+      }
+    },
+    {
+      "type": "ConstDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "INT32CONSTANT",
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 11,
+            "index": 99
+          },
+          "end": {
+            "line": 10,
+            "column": 24,
+            "index": 112
+          }
+        }
+      },
+      "fieldType": {
+        "type": "I32Keyword",
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 7,
+            "index": 95
+          },
+          "end": {
+            "line": 10,
+            "column": 10,
+            "index": 98
+          }
+        }
+      },
+      "initializer": {
+        "type": "IntConstant",
+        "value": {
+          "type": "IntegerLiteral",
+          "value": "9853",
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 27,
+              "index": 115
+            },
+            "end": {
+              "line": 10,
+              "column": 31,
+              "index": 119
+            }
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 27,
+            "index": 115
+          },
+          "end": {
+            "line": 10,
+            "column": 31,
+            "index": 119
+          }
+        }
+      },
+      "comments": [
+        {
+          "type": "CommentBlock",
+          "value": [
+            "Const1 comment"
+          ],
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 1,
+              "index": 63
+            },
+            "end": {
+              "line": 9,
+              "column": 4,
+              "index": 88
+            }
+          }
+        }
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 1,
+          "index": 89
+        },
+        "end": {
+          "line": 10,
+          "column": 31,
+          "index": 119
+        }
+      }
+    },
+    {
+      "type": "ConstDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "STRINGCONSTANT",
+        "loc": {
+          "start": {
+            "line": 13,
+            "column": 14,
+            "index": 152
+          },
+          "end": {
+            "line": 13,
+            "column": 28,
+            "index": 166
+          }
+        }
+      },
+      "fieldType": {
+        "type": "StringKeyword",
+        "loc": {
+          "start": {
+            "line": 13,
+            "column": 7,
+            "index": 145
+          },
+          "end": {
+            "line": 13,
+            "column": 13,
+            "index": 151
+          }
+        }
+      },
+      "initializer": {
+        "type": "StringLiteral",
+        "value": "hello world",
+        "loc": {
+          "start": {
+            "line": 13,
+            "column": 31,
+            "index": 169
+          },
+          "end": {
+            "line": 13,
+            "column": 44,
+            "index": 182
+          }
+        }
+      },
+      "comments": [
+        {
+          "type": "CommentLine",
+          "value": "Const2 comment",
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 1,
+              "index": 121
+            },
+            "end": {
+              "line": 12,
+              "column": 18,
+              "index": 138
+            }
+          }
+        }
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 1,
+          "index": 139
+        },
+        "end": {
+          "line": 13,
+          "column": 44,
+          "index": 182
+        }
+      }
+    },
+    {
+      "type": "EnumDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "Operation",
+        "loc": {
+          "start": {
+            "line": 18,
+            "column": 6,
+            "index": 213
+          },
+          "end": {
+            "line": 18,
+            "column": 15,
+            "index": 222
+          }
+        }
+      },
+      "members": [
+        {
+          "type": "EnumMember",
+          "name": {
+            "type": "Identifier",
+            "value": "ADD",
+            "loc": {
+              "start": {
+                "line": 19,
+                "column": 3,
+                "index": 227
+              },
+              "end": {
+                "line": 19,
+                "column": 6,
+                "index": 230
+              }
+            }
+          },
+          "initializer": {
+            "type": "IntConstant",
+            "value": {
+              "type": "IntegerLiteral",
+              "value": "1",
+              "loc": {
+                "start": {
+                  "line": 19,
+                  "column": 9,
+                  "index": 233
+                },
+                "end": {
+                  "line": 19,
+                  "column": 10,
+                  "index": 234
+                }
+              }
+            },
+            "loc": {
+              "start": {
+                "line": 19,
+                "column": 9,
+                "index": 233
+              },
+              "end": {
+                "line": 19,
+                "column": 10,
+                "index": 234
+              }
+            }
+          },
+          "comments": [],
+          "loc": {
+            "start": {
+              "line": 19,
+              "column": 3,
+              "index": 227
+            },
+            "end": {
+              "line": 19,
+              "column": 10,
+              "index": 234
+            }
+          }
+        },
+        {
+          "type": "EnumMember",
+          "name": {
+            "type": "Identifier",
+            "value": "MULTIPLY",
+            "loc": {
+              "start": {
+                "line": 21,
+                "column": 3,
+                "index": 262
+              },
+              "end": {
+                "line": 21,
+                "column": 11,
+                "index": 270
+              }
+            }
+          },
+          "initializer": null,
+          "comments": [
+            {
+              "type": "CommentLine",
+              "value": "Enum field comment",
+              "loc": {
+                "start": {
+                  "line": 20,
+                  "column": 3,
+                  "index": 238
+                },
+                "end": {
+                  "line": 20,
+                  "column": 24,
+                  "index": 259
+                }
+              }
+            }
+          ],
+          "loc": {
+            "start": {
+              "line": 21,
+              "column": 3,
+              "index": 262
+            },
+            "end": {
+              "line": 21,
+              "column": 11,
+              "index": 270
+            }
+          }
+        }
+      ],
+      "comments": [
+        {
+          "type": "CommentBlock",
+          "value": [
+            "Enum comment"
+          ],
+          "loc": {
+            "start": {
+              "line": 15,
+              "column": 1,
+              "index": 184
+            },
+            "end": {
+              "line": 17,
+              "column": 4,
+              "index": 207
+            }
+          }
+        }
+      ],
+      "loc": {
+        "start": {
+          "line": 18,
+          "column": 1,
+          "index": 208
+        },
+        "end": {
+          "line": 22,
+          "column": 2,
+          "index": 272
+        }
+      }
+    },
+    {
+      "type": "StructDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "Work",
+        "loc": {
+          "start": {
+            "line": 27,
+            "column": 8,
+            "index": 307
+          },
+          "end": {
+            "line": 27,
+            "column": 12,
+            "index": 311
+          }
+        }
+      },
+      "fields": [
+        {
+          "type": "FieldDefinition",
+          "name": {
+            "type": "Identifier",
+            "value": "num1",
+            "loc": {
+              "start": {
+                "line": 28,
+                "column": 10,
+                "index": 323
+              },
+              "end": {
+                "line": 28,
+                "column": 14,
+                "index": 327
+              }
+            }
+          },
+          "fieldID": {
+            "type": "FieldID",
+            "value": 1,
+            "loc": {
+              "start": {
+                "line": 28,
+                "column": 3,
+                "index": 316
+              },
+              "end": {
+                "line": 28,
+                "column": 5,
+                "index": 318
+              }
+            }
+          },
+          "fieldType": {
+            "type": "I32Keyword",
+            "loc": {
+              "start": {
+                "line": 28,
+                "column": 6,
+                "index": 319
+              },
+              "end": {
+                "line": 28,
+                "column": 9,
+                "index": 322
+              }
+            }
+          },
+          "requiredness": null,
+          "defaultValue": {
+            "type": "IntConstant",
+            "value": {
+              "type": "IntegerLiteral",
+              "value": "0",
+              "loc": {
+                "start": {
+                  "line": 28,
+                  "column": 17,
+                  "index": 330
+                },
+                "end": {
+                  "line": 28,
+                  "column": 18,
+                  "index": 331
+                }
+              }
+            },
+            "loc": {
+              "start": {
+                "line": 28,
+                "column": 17,
+                "index": 330
+              },
+              "end": {
+                "line": 28,
+                "column": 18,
+                "index": 331
+              }
+            }
+          },
+          "comments": [],
+          "loc": {
+            "start": {
+              "line": 28,
+              "column": 3,
+              "index": 316
+            },
+            "end": {
+              "line": 28,
+              "column": 19,
+              "index": 332
+            }
+          }
+        },
+        {
+          "type": "FieldDefinition",
+          "name": {
+            "type": "Identifier",
+            "value": "op",
+            "loc": {
+              "start": {
+                "line": 30,
+                "column": 16,
+                "index": 374
+              },
+              "end": {
+                "line": 30,
+                "column": 18,
+                "index": 376
+              }
+            }
+          },
+          "fieldID": {
+            "type": "FieldID",
+            "value": 2,
+            "loc": {
+              "start": {
+                "line": 30,
+                "column": 3,
+                "index": 361
+              },
+              "end": {
+                "line": 30,
+                "column": 5,
+                "index": 363
+              }
+            }
+          },
+          "fieldType": {
+            "type": "Identifier",
+            "value": "Operation",
+            "loc": {
+              "start": {
+                "line": 30,
+                "column": 6,
+                "index": 364
+              },
+              "end": {
+                "line": 30,
+                "column": 15,
+                "index": 373
+              }
+            }
+          },
+          "requiredness": null,
+          "defaultValue": null,
+          "comments": [
+            {
+              "type": "CommentLine",
+              "value": "Struct field comment",
+              "loc": {
+                "start": {
+                  "line": 29,
+                  "column": 3,
+                  "index": 335
+                },
+                "end": {
+                  "line": 29,
+                  "column": 26,
+                  "index": 358
+                }
+              }
+            }
+          ],
+          "loc": {
+            "start": {
+              "line": 30,
+              "column": 3,
+              "index": 361
+            },
+            "end": {
+              "line": 30,
+              "column": 19,
+              "index": 377
+            }
+          }
+        }
+      ],
+      "comments": [
+        {
+          "type": "CommentBlock",
+          "value": [
+            "Struct comment"
+          ],
+          "loc": {
+            "start": {
+              "line": 24,
+              "column": 1,
+              "index": 274
+            },
+            "end": {
+              "line": 26,
+              "column": 4,
+              "index": 299
+            }
+          }
+        }
+      ],
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 1,
+          "index": 300
+        },
+        "end": {
+          "line": 31,
+          "column": 2,
+          "index": 379
+        }
+      }
+    },
+    {
+      "type": "ServiceDefinition",
+      "name": {
+        "type": "Identifier",
+        "value": "Calculator",
+        "loc": {
+          "start": {
+            "line": 36,
+            "column": 9,
+            "index": 416
+          },
+          "end": {
+            "line": 36,
+            "column": 19,
+            "index": 426
+          }
+        }
+      },
+      "extends": {
+        "type": "Identifier",
+        "value": "shared.SharedService",
+        "loc": {
+          "start": {
+            "line": 36,
+            "column": 20,
+            "index": 427
+          },
+          "end": {
+            "line": 36,
+            "column": 48,
+            "index": 455
+          }
+        }
+      },
+      "functions": [
+        {
+          "type": "FunctionDefinition",
+          "name": {
+            "type": "Identifier",
+            "value": "add",
+            "loc": {
+              "start": {
+                "line": 42,
+                "column": 8,
+                "index": 503
+              },
+              "end": {
+                "line": 42,
+                "column": 11,
+                "index": 506
+              }
+            }
+          },
+          "returnType": {
+            "type": "I32Keyword",
+            "loc": {
+              "start": {
+                "line": 42,
+                "column": 4,
+                "index": 499
+              },
+              "end": {
+                "line": 42,
+                "column": 7,
+                "index": 502
+              }
+            }
+          },
+          "fields": [
+            {
+              "type": "FieldDefinition",
+              "name": {
+                "type": "Identifier",
+                "value": "num1",
+                "loc": {
+                  "start": {
+                    "line": 42,
+                    "column": 24,
+                    "index": 519
+                  },
+                  "end": {
+                    "line": 42,
+                    "column": 28,
+                    "index": 523
+                  }
+                }
+              },
+              "fieldID": {
+                "type": "FieldID",
+                "value": 1,
+                "loc": {
+                  "start": {
+                    "line": 42,
+                    "column": 12,
+                    "index": 507
+                  },
+                  "end": {
+                    "line": 42,
+                    "column": 14,
+                    "index": 509
+                  }
+                }
+              },
+              "fieldType": {
+                "type": "Identifier",
+                "value": "MyInteger",
+                "loc": {
+                  "start": {
+                    "line": 42,
+                    "column": 14,
+                    "index": 509
+                  },
+                  "end": {
+                    "line": 42,
+                    "column": 23,
+                    "index": 518
+                  }
+                }
+              },
+              "requiredness": null,
+              "defaultValue": null,
+              "comments": [],
+              "loc": {
+                "start": {
+                  "line": 42,
+                  "column": 12,
+                  "index": 507
+                },
+                "end": {
+                  "line": 42,
+                  "column": 29,
+                  "index": 524
+                }
+              }
+            },
+            {
+              "type": "FieldDefinition",
+              "name": {
+                "type": "Identifier",
+                "value": "num2",
+                "loc": {
+                  "start": {
+                    "line": 42,
+                    "column": 36,
+                    "index": 531
+                  },
+                  "end": {
+                    "line": 42,
+                    "column": 40,
+                    "index": 535
+                  }
+                }
+              },
+              "fieldID": {
+                "type": "FieldID",
+                "value": 2,
+                "loc": {
+                  "start": {
+                    "line": 42,
+                    "column": 30,
+                    "index": 525
+                  },
+                  "end": {
+                    "line": 42,
+                    "column": 32,
+                    "index": 527
+                  }
+                }
+              },
+              "fieldType": {
+                "type": "I32Keyword",
+                "loc": {
+                  "start": {
+                    "line": 42,
+                    "column": 32,
+                    "index": 527
+                  },
+                  "end": {
+                    "line": 42,
+                    "column": 35,
+                    "index": 530
+                  }
+                }
+              },
+              "requiredness": null,
+              "defaultValue": null,
+              "comments": [],
+              "loc": {
+                "start": {
+                  "line": 42,
+                  "column": 30,
+                  "index": 525
+                },
+                "end": {
+                  "line": 42,
+                  "column": 40,
+                  "index": 535
+                }
+              }
+            }
+          ],
+          "throws": [],
+          "comments": [
+            {
+              "type": "CommentBlock",
+              "value": [
+                "Function 1 comment"
+              ],
+              "loc": {
+                "start": {
+                  "line": 38,
+                  "column": 3,
+                  "index": 461
+                },
+                "end": {
+                  "line": 40,
+                  "column": 6,
+                  "index": 494
+                }
+              }
+            }
+          ],
+          "oneway": false,
+          "modifiers": [],
+          "loc": {
+            "start": {
+              "line": 42,
+              "column": 4,
+              "index": 499
+            },
+            "end": {
+              "line": 42,
+              "column": 42,
+              "index": 537
+            }
+          }
+        },
+        {
+          "type": "FunctionDefinition",
+          "name": {
+            "type": "Identifier",
+            "value": "zip",
+            "loc": {
+              "start": {
+                "line": 47,
+                "column": 16,
+                "index": 591
+              },
+              "end": {
+                "line": 47,
+                "column": 19,
+                "index": 594
+              }
+            }
+          },
+          "returnType": {
+            "type": "VoidKeyword",
+            "loc": {
+              "start": {
+                "line": 47,
+                "column": 11,
+                "index": 586
+              },
+              "end": {
+                "line": 47,
+                "column": 15,
+                "index": 590
+              }
+            }
+          },
+          "fields": [
+            {
+              "type": "FieldDefinition",
+              "name": {
+                "type": "Identifier",
+                "value": "vasia",
+                "loc": {
+                  "start": {
+                    "line": 47,
+                    "column": 26,
+                    "index": 601
+                  },
+                  "end": {
+                    "line": 47,
+                    "column": 31,
+                    "index": 606
+                  }
+                }
+              },
+              "fieldID": {
+                "type": "FieldID",
+                "value": 1,
+                "loc": {
+                  "start": {
+                    "line": 47,
+                    "column": 20,
+                    "index": 595
+                  },
+                  "end": {
+                    "line": 47,
+                    "column": 22,
+                    "index": 597
+                  }
+                }
+              },
+              "fieldType": {
+                "type": "I32Keyword",
+                "loc": {
+                  "start": {
+                    "line": 47,
+                    "column": 22,
+                    "index": 597
+                  },
+                  "end": {
+                    "line": 47,
+                    "column": 25,
+                    "index": 600
+                  }
+                }
+              },
+              "requiredness": null,
+              "defaultValue": null,
+              "comments": [],
+              "loc": {
+                "start": {
+                  "line": 47,
+                  "column": 20,
+                  "index": 595
+                },
+                "end": {
+                  "line": 47,
+                  "column": 31,
+                  "index": 606
+                }
+              }
+            }
+          ],
+          "throws": [],
+          "comments": [
+            {
+              "type": "CommentBlock",
+              "value": [
+                "Function 2 comment"
+              ],
+              "loc": {
+                "start": {
+                  "line": 44,
+                  "column": 4,
+                  "index": 542
+                },
+                "end": {
+                  "line": 46,
+                  "column": 6,
+                  "index": 575
+                }
+              }
+            }
+          ],
+          "oneway": true,
+          "modifiers": [
+            {
+              "type": "OnewayKeyword",
+              "text": "oneway",
+              "loc": {
+                "start": {
+                  "line": 47,
+                  "column": 4,
+                  "index": 579
+                },
+                "end": {
+                  "line": 47,
+                  "column": 10,
+                  "index": 585
+                }
+              }
+            }
+          ],
+          "loc": {
+            "start": {
+              "line": 47,
+              "column": 11,
+              "index": 586
+            },
+            "end": {
+              "line": 47,
+              "column": 32,
+              "index": 607
+            }
+          }
+        }
+      ],
+      "comments": [
+        {
+          "type": "CommentBlock",
+          "value": [
+            "Service comment"
+          ],
+          "loc": {
+            "start": {
+              "line": 33,
+              "column": 1,
+              "index": 381
+            },
+            "end": {
+              "line": 35,
+              "column": 4,
+              "index": 407
+            }
+          }
+        }
+      ],
+      "loc": {
+        "start": {
+          "line": 36,
+          "column": 1,
+          "index": 408
+        },
+        "end": {
+          "line": 49,
+          "column": 2,
+          "index": 610
+        }
+      }
+    }
+  ]
+}

--- a/src/tests/parser/solutions/complex-comments.solution.json
+++ b/src/tests/parser/solutions/complex-comments.solution.json
@@ -25,32 +25,32 @@
                     "type": "FunctionDefinition",
                     "name": {
                         "type": "Identifier",
-                        "value": "ping",
+                        "value": "ding",
                         "loc": {
                             "start": {
-                                "line": 10,
-                                "column": 41,
-                                "index": 184
+                                "line": 12,
+                                "column": 9,
+                                "index": 192
                             },
                             "end": {
-                                "line": 10,
-                                "column": 45,
-                                "index": 188
+                                "line": 12,
+                                "column": 13,
+                                "index": 196
                             }
                         }
                     },
                     "returnType": {
-                        "type": "BoolKeyword",
+                        "type": "I32Keyword",
                         "loc": {
                             "start": {
-                                "line": 10,
+                                "line": 12,
                                 "column": 5,
-                                "index": 148
+                                "index": 188
                             },
                             "end": {
-                                "line": 10,
-                                "column": 9,
-                                "index": 152
+                                "line": 12,
+                                "column": 8,
+                                "index": 191
                             }
                         }
                     },
@@ -58,36 +58,18 @@
                     "throws": [],
                     "comments": [
                         {
-                            "type": "CommentBlock",
-                            "value": [
-                                "should this be required?"
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 10,
-                                    "column": 10,
-                                    "index": 153
-                                },
-                                "end": {
-                                    "line": 10,
-                                    "column": 40,
-                                    "index": 183
-                                }
-                            }
-                        },
-                        {
                             "type": "CommentLine",
                             "value": "bool foo();",
                             "loc": {
                                 "start": {
-                                    "line": 11,
+                                    "line": 10,
                                     "column": 5,
-                                    "index": 195
+                                    "index": 148
                                 },
                                 "end": {
-                                    "line": 11,
+                                    "line": 10,
                                     "column": 18,
-                                    "index": 208
+                                    "index": 161
                                 }
                             }
                         },
@@ -96,14 +78,14 @@
                             "value": "string dang(),",
                             "loc": {
                                 "start": {
-                                    "line": 12,
+                                    "line": 11,
                                     "column": 5,
-                                    "index": 213
+                                    "index": 166
                                 },
                                 "end": {
-                                    "line": 12,
+                                    "line": 11,
                                     "column": 22,
-                                    "index": 230
+                                    "index": 183
                                 }
                             }
                         }
@@ -112,65 +94,14 @@
                     "modifiers": [],
                     "loc": {
                         "start": {
-                            "line": 10,
+                            "line": 12,
                             "column": 5,
-                            "index": 148
+                            "index": 188
                         },
                         "end": {
-                            "line": 10,
-                            "column": 47,
-                            "index": 190
-                        }
-                    }
-                },
-                {
-                    "type": "FunctionDefinition",
-                    "name": {
-                        "type": "Identifier",
-                        "value": "ding",
-                        "loc": {
-                            "start": {
-                                "line": 13,
-                                "column": 9,
-                                "index": 239
-                            },
-                            "end": {
-                                "line": 13,
-                                "column": 13,
-                                "index": 243
-                            }
-                        }
-                    },
-                    "returnType": {
-                        "type": "I32Keyword",
-                        "loc": {
-                            "start": {
-                                "line": 13,
-                                "column": 5,
-                                "index": 235
-                            },
-                            "end": {
-                                "line": 13,
-                                "column": 8,
-                                "index": 238
-                            }
-                        }
-                    },
-                    "fields": [],
-                    "throws": [],
-                    "comments": [],
-                    "oneway": false,
-                    "modifiers": [],
-                    "loc": {
-                        "start": {
-                            "line": 13,
-                            "column": 5,
-                            "index": 235
-                        },
-                        "end": {
-                            "line": 13,
+                            "line": 12,
                             "column": 15,
-                            "index": 245
+                            "index": 198
                         }
                     }
                 }
@@ -238,9 +169,9 @@
                     "index": 129
                 },
                 "end": {
-                    "line": 14,
+                    "line": 13,
                     "column": 2,
-                    "index": 247
+                    "index": 200
                 }
             }
         }

--- a/src/tests/parser/solutions/enum-commented.solution.json
+++ b/src/tests/parser/solutions/enum-commented.solution.json
@@ -54,24 +54,7 @@
                     }
                 }
             ],
-            "comments": [
-                {
-                    "type": "CommentLine",
-                    "value": "TWO",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5,
-                            "index": 25
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 10,
-                            "index": 30
-                        }
-                    }
-                }
-            ],
+            "comments": [],
             "loc": {
                 "start": {
                     "line": 1,

--- a/src/tests/parser/solutions/service-commented.solution.json
+++ b/src/tests/parser/solutions/service-commented.solution.json
@@ -56,24 +56,7 @@
                     },
                     "fields": [],
                     "throws": [],
-                    "comments": [
-                        {
-                            "type": "CommentLine",
-                            "value": "void ping()",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 5,
-                                    "index": 35
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 18,
-                                    "index": 48
-                                }
-                            }
-                        }
-                    ],
+                    "comments": [],
                     "oneway": false,
                     "modifiers": [],
                     "loc": {

--- a/src/tests/parser/solutions/struct-commented.solution.json
+++ b/src/tests/parser/solutions/struct-commented.solution.json
@@ -86,24 +86,7 @@
                     }
                 }
             ],
-            "comments": [
-                {
-                    "type": "CommentLine",
-                    "value": "2: required bool field2,",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5,
-                            "index": 46
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 31,
-                            "index": 72
-                        }
-                    }
-                }
-            ],
+            "comments": [],
             "loc": {
                 "start": {
                     "line": 1,


### PR DESCRIPTION
1. Map leading comments to the following data;
2. Disregard any other comments
Follows official Thrift CLI behavior with additional feature of mapping comments to the fields, which official one doesn't perform.