### PR TITLE
Fixes string scanning and adds escaping support

### DIFF
--- a/src/tests/scanner/fixtures/double-quotes.txt
+++ b/src/tests/scanner/fixtures/double-quotes.txt
@@ -1,1 +1,3 @@
-"this is a test"
+"isn't this a test!"
+"this isn\'t a test!"
+"this is a \"test\""

--- a/src/tests/scanner/fixtures/single-quotes.txt
+++ b/src/tests/scanner/fixtures/single-quotes.txt
@@ -1,1 +1,3 @@
-'this is a test'
+'this is a \"test"'
+'this isn\'t a test'
+'this is a \'test\''

--- a/src/tests/scanner/solutions/double-quotes.solution.json
+++ b/src/tests/scanner/solutions/double-quotes.solution.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "StringLiteral",
-        "text": "this is a test",
+        "text": "isn't this a test!",
         "loc": {
             "start": {
                 "line": 1,
@@ -10,8 +10,40 @@
             },
             "end": {
                 "line": 1,
-                "column": 17,
-                "index": 16
+                "column": 21,
+                "index": 20
+            }
+        }
+    },
+    {
+        "type": "StringLiteral",
+        "text": "this isn't a test!",
+        "loc": {
+            "start": {
+                "line": 2,
+                "column": 1,
+                "index": 21
+            },
+            "end": {
+                "line": 2,
+                "column": 22,
+                "index": 42
+            }
+        }
+    },
+    {
+        "type": "StringLiteral",
+        "text": "this is a \"test\"",
+        "loc": {
+            "start": {
+                "line": 3,
+                "column": 1,
+                "index": 43
+            },
+            "end": {
+                "line": 3,
+                "column": 21,
+                "index": 63
             }
         }
     },
@@ -20,14 +52,14 @@
         "text": "",
         "loc": {
             "start": {
-                "line": 1,
-                "column": 17,
-                "index": 17
+                "line": 3,
+                "column": 21,
+                "index": 64
             },
             "end": {
-                "line": 2,
+                "line": 4,
                 "column": 1,
-                "index": 17
+                "index": 64
             }
         }
     }

--- a/src/tests/scanner/solutions/single-quotes.solution.json
+++ b/src/tests/scanner/solutions/single-quotes.solution.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "StringLiteral",
-        "text": "this is a test",
+        "text": "this is a \"test\"",
         "loc": {
             "start": {
                 "line": 1,
@@ -10,8 +10,40 @@
             },
             "end": {
                 "line": 1,
-                "column": 17,
-                "index": 16
+                "column": 20,
+                "index": 19
+            }
+        }
+    },
+    {
+        "type": "StringLiteral",
+        "text": "this isn't a test",
+        "loc": {
+            "start": {
+                "line": 2,
+                "column": 1,
+                "index": 20
+            },
+            "end": {
+                "line": 2,
+                "column": 21,
+                "index": 40
+            }
+        }
+    },
+    {
+        "type": "StringLiteral",
+        "text": "this is a 'test'",
+        "loc": {
+            "start": {
+                "line": 3,
+                "column": 1,
+                "index": 41
+            },
+            "end": {
+                "line": 3,
+                "column": 21,
+                "index": 61
             }
         }
     },
@@ -20,14 +52,14 @@
         "text": "",
         "loc": {
             "start": {
-                "line": 1,
-                "column": 17,
-                "index": 17
+                "line": 3,
+                "column": 21,
+                "index": 62
             },
             "end": {
-                "line": 2,
+                "line": 4,
                 "column": 1,
-                "index": 17
+                "index": 62
             }
         }
     }


### PR DESCRIPTION
Fixes an issue where double quoted string literals that contained single quotes (or vice verca) failed to parse correctly (e.g. "Isn't").

Adds support for escaping quotes within a string literal (e.g. "This is a \\"test\\"") now parsers correctly.