### PR TITLE
Handle trailing comma of const map

### DIFF
--- a/src/main/parser.ts
+++ b/src/main/parser.ts
@@ -833,6 +833,11 @@ export function createParser(tokens: Array<Token>, report: ErrorReporter = noopR
 
       if (check(SyntaxType.CommaToken)) {
         advance()
+
+        // trailing comma
+        if (check(SyntaxType.RightBraceToken)) {
+          break
+        }
       } else {
         break
       }

--- a/src/tests/parser/fixtures/const-map.thrift
+++ b/src/tests/parser/fixtures/const-map.thrift
@@ -1,1 +1,6 @@
 const map<string,string> MAP_CONST = {'hello': 'world', 'foo': 'bar' }
+
+const map<string,string> MAP_CONST_WITH_TRAILING_COMMA = {
+    'hello': 'world',
+    'foo': 'bar',
+}

--- a/src/tests/parser/solutions/const-map.solution.json
+++ b/src/tests/parser/solutions/const-map.solution.json
@@ -188,6 +188,194 @@
                     "index": 70
                 }
             }
+        },
+        {
+            "type": "ConstDefinition",
+            "name": {
+                "type": "Identifier",
+                "value": "MAP_CONST_WITH_TRAILING_COMMA",
+                "loc": {
+                    "start": {
+                        "line": 3,
+                        "column": 26,
+                        "index": 97
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 55,
+                        "index": 126
+                    }
+                }
+            },
+            "fieldType": {
+                "type": "MapType",
+                "keyType": {
+                    "type": "StringKeyword",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 11,
+                            "index": 82
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 17,
+                            "index": 88
+                        }
+                    }
+                },
+                "valueType": {
+                    "type": "StringKeyword",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 18,
+                            "index": 89
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 24,
+                            "index": 95
+                        }
+                    }
+                },
+                "loc": {
+                    "start": {
+                        "line": 3,
+                        "column": 10,
+                        "index": 81
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 25,
+                        "index": 96
+                    }
+                }
+            },
+            "initializer": {
+                "type": "ConstMap",
+                "properties": [
+                    {
+                        "type": "PropertyAssignment",
+                        "name": {
+                            "type": "StringLiteral",
+                            "value": "hello",
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 5,
+                                    "index": 135
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 12,
+                                    "index": 142
+                                }
+                            }
+                        },
+                        "initializer": {
+                            "type": "StringLiteral",
+                            "value": "world",
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 14,
+                                    "index": 144
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 21,
+                                    "index": 151
+                                }
+                            }
+                        },
+                        "loc": {
+                            "start": {
+                                "line": 4,
+                                "column": 5,
+                                "index": 135
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 21,
+                                "index": 151
+                            }
+                        }
+                    },
+                    {
+                        "type": "PropertyAssignment",
+                        "name": {
+                            "type": "StringLiteral",
+                            "value": "foo",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 5,
+                                    "index": 157
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 10,
+                                    "index": 162
+                                }
+                            }
+                        },
+                        "initializer": {
+                            "type": "StringLiteral",
+                            "value": "bar",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 12,
+                                    "index": 164
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 17,
+                                    "index": 169
+                                }
+                            }
+                        },
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 5,
+                                "index": 157
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 17,
+                                "index": 169
+                            }
+                        }
+                    }
+                ],
+                "loc": {
+                    "start": {
+                        "line": 4,
+                        "column": 5,
+                        "index": 135
+                    },
+                    "end": {
+                        "line": 6,
+                        "column": 2,
+                        "index": 172
+                    }
+                }
+            },
+            "comments": [],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 1,
+                    "index": 72
+                },
+                "end": {
+                    "line": 6,
+                    "column": 2,
+                    "index": 172
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
Example:

```thrift
const map<string,string> MAP_CONST_WITH_TRAILING_COMMA = {
    'hello': 'world',
    'foo': 'bar',
}
```