### PR TITLE
Implement cpp_include parser

### DIFF
--- a/src/main/organizer.ts
+++ b/src/main/organizer.ts
@@ -1,5 +1,6 @@
 import {
     ConstDefinition,
+    CppIncludeDefinition,
     EnumDefinition,
     ExceptionDefinition,
     IncludeDefinition,
@@ -15,6 +16,7 @@ import {
 export function organize(raw: ThriftDocument): ThriftDocument {
     const namespaces: Array<NamespaceDefinition> = []
     const includes: Array<IncludeDefinition> = []
+    const cppIncludes: Array<CppIncludeDefinition> = []
     const constants: Array<ConstDefinition> = []
     const enums: Array<EnumDefinition> = []
     const typedefs: Array<TypedefDefinition> = []
@@ -31,6 +33,10 @@ export function organize(raw: ThriftDocument): ThriftDocument {
 
             case SyntaxType.IncludeDefinition:
                 includes.push(next)
+                break
+
+            case SyntaxType.CppIncludeDefinition:
+                cppIncludes.push(next)
                 break
 
             case SyntaxType.CppIncludeDefinition:
@@ -76,6 +82,7 @@ export function organize(raw: ThriftDocument): ThriftDocument {
         body: [
             ...namespaces,
             ...includes,
+            ...cppIncludes,
             ...enums,
             ...typedefs,
             ...constants,

--- a/src/main/parser.ts
+++ b/src/main/parser.ts
@@ -6,6 +6,7 @@ import {
     ConstList,
     ConstMap,
     ConstValue,
+    CppIncludeDefinition,
     DoubleConstant,
     EnumDefinition,
     EnumMember,
@@ -69,6 +70,7 @@ function isStatementBeginning(token: Token): boolean {
     switch (token.type) {
         case SyntaxType.NamespaceKeyword:
         case SyntaxType.IncludeKeyword:
+        case SyntaxType.CppIncludeDefinition:
         case SyntaxType.ConstKeyword:
         case SyntaxType.StructKeyword:
         case SyntaxType.UnionKeyword:
@@ -139,6 +141,9 @@ export function createParser(
             case SyntaxType.IncludeKeyword:
                 return parseInclude()
 
+            case SyntaxType.CppIncludeKeyword:
+                return parseCppInclude()
+
             case SyntaxType.ConstKeyword:
                 return parseConst()
 
@@ -187,6 +192,26 @@ export function createParser(
 
         return {
             type: SyntaxType.IncludeDefinition,
+            path: createStringLiteral(pathToken.text, pathToken.loc),
+            comments: getComments(),
+            loc: createTextLocation(keywordToken.loc.start, pathToken.loc.end),
+        }
+    }
+
+    function parseCppInclude(): CppIncludeDefinition {
+        const _keywordToken: Token | null = consume(SyntaxType.CppIncludeKeyword)
+        const keywordToken = requireValue(
+            _keywordToken,
+            `'cpp_include' keyword expected`,
+        )
+        const _pathToken: Token | null = consume(SyntaxType.StringLiteral)
+        const pathToken = requireValue(
+            _pathToken,
+            `Cpp include statement must include a path as string literal`,
+        )
+
+        return {
+            type: SyntaxType.CppIncludeDefinition,
             path: createStringLiteral(pathToken.text, pathToken.loc),
             comments: getComments(),
             loc: createTextLocation(keywordToken.loc.start, pathToken.loc.end),

--- a/src/tests/parser/fixtures/cpp_include.thrift
+++ b/src/tests/parser/fixtures/cpp_include.thrift
@@ -1,0 +1,2 @@
+cpp_include 'test'
+

--- a/src/tests/parser/parser.spec.ts
+++ b/src/tests/parser/parser.spec.ts
@@ -128,6 +128,19 @@ describe('Parser', () => {
         assert.deepEqual(objectify(thrift), expected)
     })
 
+    it('should correctly parse the syntax of an cpp_include', () => {
+        const content: string = loadSource('cpp_include')
+        const scanner: Scanner = createScanner(content)
+        const tokens: Array<Token> = scanner.scan()
+
+        const parser: Parser = createParser(tokens)
+        const thrift: ThriftDocument = parser.parse()
+
+        const expected: any = loadSolution('cpp_include')
+
+        assert.deepEqual(objectify(thrift), expected)
+    })
+
     it('should correctly parse the syntax of a namespace definition', () => {
         const content: string = loadSource('namespace')
         const scanner: Scanner = createScanner(content)

--- a/src/tests/parser/solutions/cpp_include.solution.json
+++ b/src/tests/parser/solutions/cpp_include.solution.json
@@ -1,0 +1,37 @@
+{
+    "type": "ThriftDocument",
+    "body": [
+        {
+            "type": "CppIncludeDefinition",
+            "path": {
+                "type": "StringLiteral",
+                "value": "test",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 13,
+                        "index": 12
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 19,
+                        "index": 18
+                    }
+                }
+            },
+            "comments": [],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 1,
+                    "index": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19,
+                    "index": 18
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
It seems that the current version does not include the implementation of `cpp_include` entries and it throws an error when running into it. This PR implements the parsing logic for `cpp_include`. It mimics the code for `include` syntax.